### PR TITLE
fix(node): await Promise returns from async JS hook handlers

### DIFF
--- a/bindings/node/__tests__/hooks.test.ts
+++ b/bindings/node/__tests__/hooks.test.ts
@@ -85,4 +85,44 @@ describe('JsHookRegistry', () => {
     expect(parsed).toHaveProperty('custom', 'value')
     expect(parsed).toHaveProperty('tool', 'grep')
   })
+
+  it('supports async handlers returning Promise<string>', async () => {
+    const registry = new JsHookRegistry()
+    let handlerCalled = false
+    let receivedEvent = ''
+
+    registry.register('tool:pre', async (event: string, _data: string) => {
+      handlerCalled = true
+      receivedEvent = event
+      // Simulate async work (e.g. I/O)
+      await new Promise<void>(resolve => setImmediate(() => resolve()))
+      return JSON.stringify({ action: 'continue' })
+    }, 10, 'async-hook')
+
+    const result = await registry.emit('tool:pre', '{"tool":"grep"}')
+
+    expect(handlerCalled).toBe(true)
+    expect(receivedEvent).toBe('tool:pre')
+    expect(result.action).toBe(HookAction.Continue)
+  })
+
+  it('async handler returning deny short-circuits pipeline', async () => {
+    const registry = new JsHookRegistry()
+    let secondRan = false
+
+    registry.register('tool:pre', async (_event: string, _data: string) => {
+      await new Promise<void>(resolve => setImmediate(() => resolve()))
+      return JSON.stringify({ action: 'deny', reason: 'async blocked' })
+    }, 10, 'async-deny')
+    registry.register('tool:pre', (_event: string, _data: string) => {
+      secondRan = true
+      return JSON.stringify({ action: 'continue' })
+    }, 20, 'after')
+
+    const result = await registry.emit('tool:pre', '{"tool":"rm"}')
+
+    expect(result.action).toBe(HookAction.Deny)
+    expect(result.reason).toBe('async blocked')
+    expect(secondRan).toBe(false)
+  })
 })

--- a/bindings/node/src/hooks.rs
+++ b/bindings/node/src/hooks.rs
@@ -43,7 +43,10 @@ impl HookHandler for JsHookHandlerBridge {
             "{}".to_string()
         });
         Box::pin(async move {
-            let result_str: String =
+            // The JS handler may return either a bare string (synchronous) or a
+            // Promise<String> (async). `call_async` returns whatever the JS
+            // function returned — accept both via `Either`.
+            let ret: Either<String, napi::bindgen_prelude::Promise<String>> =
                 self.callback
                     .call_async((event, data_str))
                     .await
@@ -51,6 +54,13 @@ impl HookHandler for JsHookHandlerBridge {
                         message: e.to_string(),
                         handler_name: None,
                     })?;
+            let result_str: String = match ret {
+                Either::A(s) => s,
+                Either::B(promise) => promise.await.map_err(|e| HookError::HandlerFailed {
+                    message: e.to_string(),
+                    handler_name: None,
+                })?,
+            };
             let hook_result: HookResult = serde_json::from_str(&result_str).unwrap_or_else(|e| {
                 log::error!(
                     "SECURITY: Hook handler returned unparseable result — failing closed (Deny): {e} — json: {result_str}"


### PR DESCRIPTION
## TL;DR

**The Node.js binding crashes the host process whenever an async JS hook handler is registered.** Sync-only handlers work; any handler declared `async` — which is the only way to do I/O — triggers an unrecoverable FATAL ERROR from napi-rs, taking the whole process down. The fix is a 6-line change; the binding has been shipped with this bug since async support was advertised in the public API.

## Reproduction (30 seconds)

This is a complete repro. Nothing unusual — a handler that awaits before returning:

```ts
import { JsHookRegistry } from 'amplifier-core'

const registry = new JsHookRegistry()

registry.register('tool:pre', async (event, data) => {
  // Any await — a DB write, a fetch, a fs read, a setImmediate…
  await new Promise(r => setImmediate(r))
  return JSON.stringify({ action: 'continue' })
}, 10, 'logger')

await registry.emit('tool:pre', '{"tool":"grep"}')
```

Actual result:

```
FATAL ERROR: threadsafe_function.rs:749 Failed to convert return value in
ThreadsafeFunction callback into Rust value: StringExpected, Failed to
convert JavaScript value `Object {}` into rust type `String`
----- Native stack trace -----
 1: node::OnFatalError
 2: napi_open_callback_scope
 3: amplifier-core.darwin-arm64.node
 4: v8impl::ThreadSafeFunction::AsyncCb
...
```

The process is gone. No exception to catch, no `.catch()` hook can save you — `FATAL ERROR` calls `node::OnFatalError` and exits.

## Why this makes the binding unusable in practice

Every real-world hook needs to await something:

- `activity-logger` — writes to disk
- `token-tracker` — reads a store, updates it, persists
- `approval-emitter` — awaits a user decision via IPC
- `status-context` — fetches current session state
- `todo-reminder` — reads a file, injects context
- Any hook that calls a DB, HTTP endpoint, or filesystem

None of these are exotic — they're the canonical uses of hooks in the kernel's own design (pre/post tool, context injection, approval, logging). **You cannot build any of them today without crashing the process.** The only hooks that work are pure-compute transforms (count tokens already in memory, rewrite a string), which is a tiny fraction of what the hook system exists to do.

Result: the documented `JsHookRegistry` API is effectively dead — it works for toy examples and crashes for anything real.

## Why this wasn't caught

Every handler in `bindings/node/__tests__/hooks.test.ts` is synchronous. The JSDoc on `register()` explicitly says both forms are supported:

```ts
/// (event: string, dataJson: string) => string | Promise<string>
```

…but the test matrix never covered the Promise case, and the Rust side never awaited it. The sibling `JsToolBridge::execute` in `bindings/node/src/tools.rs` handles the same pattern correctly — it awaits a `Promise<String>` from its JS callback. The hook bridge predates that pattern and was never updated. This PR brings the two into alignment.

## Root cause

`JsHookHandlerBridge::handle` reads the JS callback's return value as `String`:

```rust
let result_str: String = self.callback.call_async(...).await?;
```

`async` functions return `Promise`, which napi-rs cannot coerce into `String`. The `ThreadsafeFunction<_, ErrorStrategy::Fatal>` treats conversion failure as a fatal error per its contract — hence the process crash rather than a recoverable error.

## Fix (6 lines of real change)

Accept both sync and async return types via `Either<String, Promise<String>>`, awaiting the promise branch:

```rust
let ret: Either<String, Promise<String>> = self.callback.call_async(...).await?;
let result_str: String = match ret {
    Either::A(s) => s,
    Either::B(promise) => promise.await?,
};
```

Sync handlers continue to work unchanged — they take the `Either::A` path with no semantic or performance difference. Async handlers now work instead of crashing the process. This is exactly the pattern `JsToolBridge::execute` already uses.

## Tests

Two new cases in `__tests__/hooks.test.ts`, each of which crashes the process on the unpatched binary:

1. `supports async handlers returning Promise<string>` — async handler returns `Continue`, verify no crash and result propagates.
2. `async handler returning deny short-circuits pipeline` — async `Deny` must prevent subsequent handlers from running (verifies the Deny precedence still holds through the async path).

Full suite after patch: **70/70 passing**, including the 7 pre-existing hook tests.

## Risk

Zero for existing users. Sync handlers take the same path they always did. Async handlers — which **cannot work today** — now work. This cannot regress any working code.

## Severity

High. Any consumer of the Node binding attempting to write a production-grade hook (i.e. one that awaits) will hit this as their first integration test. The binding is advertising an API it can't deliver.
