### PR TITLE
feat(lifecycle): add on_session_ready() post-composition lifecycle hook

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -184,6 +184,177 @@ These types stay as Python by design — they are app-layer concerns, not kernel
 
 ---
 
+## Module Lifecycle Methods
+
+Modules may expose lifecycle methods that the kernel calls at specific points during
+initialisation.
+
+### `mount(coordinator, config)` — Required
+
+```python
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+async def mount(coordinator, config: dict[str, Any] | None = None) -> Callable[[], None | Awaitable[None]] | None:
+    ...
+```
+
+Module-level free function — no `self`. Called once per module, in **phase order**,
+when the kernel loads and wires the module into the coordinator. At call time the
+coordinator is **partially composed** — modules from earlier phases are accessible,
+but later-phase modules may not yet be present.
+
+**Return value — optional cleanup callable:**
+
+`mount()` may return a zero-argument cleanup callable, or `None` (no cleanup needed).
+
+| Returned value | Kernel behaviour |
+|----------------|-----------------|
+| `None` | Silently ignored — no cleanup registered |
+| Non-callable (e.g. `dict`) | **Silently ignored** — `register_cleanup` only stores callables |
+| Sync callable | Stored; called with no args at teardown. If the call returns a coroutine it is awaited |
+| Async callable | Stored; at teardown the coroutine is obtained and **awaited** via `pyo3_async_runtimes::tokio::into_future` |
+
+The canonical form is an `async def cleanup()` nested closure:
+
+```python
+async def mount(coordinator, config: dict[str, Any] | None = None):
+    client = await MyClient.connect((config or {}).get("url"))
+    coordinator.register_capability("my.client", client)
+
+    async def cleanup() -> None:
+        await client.aclose()
+
+    return cleanup  # kernel awaits this at session teardown
+```
+
+Cleanup callables are called with **no arguments**, in **reverse registration order**
+(last-mounted module is cleaned up first). Errors in one cleanup callable are logged
+but do not prevent the remaining callables from running.
+
+Source reference: `bindings/python/src/coordinator/mod.rs::cleanup()` and
+`bindings/python/src/coordinator/capabilities.rs::register_cleanup()`.
+
+### `on_session_ready(coordinator)` — Optional
+
+```python
+async def on_session_ready(coordinator) -> None:
+    ...
+```
+
+Called **after ALL modules across all phases have completed `mount()`**. By the time
+`on_session_ready()` runs, the coordinator is fully composed and every contributed tool, hook,
+and provider is registered.
+
+#### `on_session_ready()` Contract
+
+| Property | Value |
+|----------|-------|
+| Presence | Optional |
+| Signature | `async def on_session_ready(coordinator) -> None` — no `config` param, no `self` |
+| Sync check | **Must** be `async`; a sync `on_session_ready` logs a warning and is skipped |
+| Return value | Ignored |
+| Exceptions | Non-fatal — caught and logged as warnings with `exc_info=True` |
+| Call order | Same as `mount()` order (phase order, then registration order within a phase) |
+| Timing | After all phases complete `mount()`, before `session:fork` is emitted |
+| Scope | Python-only — see polyglot note below |
+
+**Fork behaviour:** `on_session_ready` fires once per session. When a parent session forks a
+child session (the `session:fork` event), the child runs its own independent mount wave and
+its own `on_session_ready` pass — in the same order as its own module registration. A parent's
+`on_session_ready` callbacks do not run again for the child.
+
+**Dispatch ordering:** Callbacks fire **sequentially** in module registration order (orchestrator
+first, then context, then providers, tools, and hooks within each phase in load order). This
+ordering is stable and guaranteed. Cross-module assumptions built on this ordering are safe.
+
+**Failure isolation:** A raised exception in one module's `on_session_ready` is caught, logged as
+a WARNING with `exc_info=True`, and does not prevent remaining modules' callbacks from running.
+
+**No timeout:** The kernel enforces no timeout on `on_session_ready` callbacks. A hanging callback
+hangs the session. This is a deliberate absence — documenting it now prevents surprise if a timeout
+is added later (adding one is a breaking change).
+
+**Observability event:** On `on_session_ready` failure, the kernel emits a
+`module:on_session_ready_failed` event with payload `{"module_id": str, "error": str}`, in
+addition to the WARNING log. Log-only failures are invisible to observability hooks.
+
+#### When to use `on_session_ready()`
+
+- **Discovering contributions from other modules** — read the fully-composed coordinator
+  to inspect tools, hooks, or providers registered by peers.
+- **Wiring cross-module dependencies** — subscribe to hooks or capabilities that are only
+  present after another module mounts.
+- **Eliminating dual-path patterns** — avoid the anti-pattern of checking for a capability
+  in both `mount()` (not yet available) and in a request handler (too late to configure).
+
+**Before `on_session_ready` (dual-path anti-pattern) — process-scoped global, unsafe for multi-session deployments:**
+
+```python
+# Before (anti-pattern) — process-scoped global, unsafe for multi-session deployments
+_coordinator = None  # ← shared across ALL sessions in the process
+
+async def mount(coordinator, config: dict | None = None) -> None:
+    global _coordinator
+    _coordinator = coordinator
+
+async def handle_request(request):
+    if _coordinator and _coordinator.get("tools", {}).get("search"):
+        result = await _coordinator.get("tools")["search"].execute(**request.params)
+```
+
+**After `on_session_ready` (correct) — session-scoped via closure, safe for multi-session deployments:**
+
+```python
+# After (correct) — session-scoped via closure, safe for multi-session deployments
+async def mount(coordinator, config: dict | None = None) -> None:
+    pass  # nothing cross-module to wire here
+
+async def on_session_ready(coordinator) -> None:
+    # Session-scoped: register_capability stores reference per-session on the coordinator
+    tools = coordinator.get("tools") or {}
+    search_tool = tools.get("search")
+    if search_tool:
+        coordinator.register_capability("my_module.search_tool", search_tool)
+
+async def handle_request(coordinator, request):
+    search_tool = coordinator.get_capability("my_module.search_tool")
+    if search_tool:
+        result = await search_tool.execute(**request.params)
+```
+
+> **Cleanup from `on_session_ready()`:** `on_session_ready()`'s return value is ignored. If a
+> resource allocated in `on_session_ready()` needs teardown, register the cleanup directly:
+> `coordinator.register_cleanup(my_async_cleanup_fn)`.
+
+#### Canonical use case: event subscription after full composition
+
+```python
+# Canonical on_session_ready pattern: event discovery + subscription
+# (from hooks-logging, the primary motivating adopter)
+
+async def mount(coordinator, config: dict | None = None):
+    pass  # store config-derived state if needed
+
+async def on_session_ready(coordinator) -> None:
+    # All modules mounted — event contributions are complete
+    all_events = set(ALL_EVENTS)  # core canonical events
+    contributions = await coordinator.collect_contributions("observability.events")
+    for event_list in contributions:
+        all_events.update(event_list)
+    # delegate:agent_spawned, delegate:agent_completed are now guaranteed present
+    for event in all_events:
+        coordinator.hooks.register(event, my_handler, name="my-module")
+```
+
+#### Polyglot note
+
+`on_session_ready()` is **Python-only**. WASM, gRPC, and native Rust modules do not participate
+in the `on_session_ready()` wave. If a polyglot module needs post-composition behaviour, defer
+it to a request-time check or emit a custom event that Python modules can subscribe to.
+
+---
+
 ## Event Constants
 
 Canonical event names are defined in `crates/amplifier-core/src/events.rs` (Rust)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "amplifier-core"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "log",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "amplifier-core-py"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "amplifier-core",
  "log",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core-py"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2021"
 description = "PyO3 bridge for amplifier-core Rust kernel"
 license = "MIT"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -248,6 +248,12 @@ fn _engine(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("CANCEL_REQUESTED", amplifier_core::events::CANCEL_REQUESTED)?;
     m.add("CANCEL_COMPLETED", amplifier_core::events::CANCEL_COMPLETED)?;
 
+    // Module lifecycle events
+    m.add(
+        "MODULE_ON_SESSION_READY_FAILED",
+        amplifier_core::events::MODULE_ON_SESSION_READY_FAILED,
+    )?;
+
     // Aggregate list of all events
     m.add("ALL_EVENTS", amplifier_core::events::ALL_EVENTS.to_vec())?;
 

--- a/bindings/python/tests/test_event_constants.py
+++ b/bindings/python/tests/test_event_constants.py
@@ -93,7 +93,7 @@ class TestAllEventsList:
     def test_all_events_count(self):
         from amplifier_core.events import ALL_EVENTS
 
-        assert len(ALL_EVENTS) == 41, f"Expected 41 events, got {len(ALL_EVENTS)}"
+        assert len(ALL_EVENTS) == 42, f"Expected 42 events, got {len(ALL_EVENTS)}"
 
     def test_all_events_contains_all_constants(self):
         import amplifier_core.events as events

--- a/bindings/python/tests/test_python_stubs.py
+++ b/bindings/python/tests/test_python_stubs.py
@@ -23,7 +23,7 @@ def test_events_reexport_provider_throttle():
 def test_events_reexport_all_events():
     from amplifier_core.events import ALL_EVENTS
 
-    assert len(ALL_EVENTS) == 41
+    assert len(ALL_EVENTS) == 42
 
 
 def test_capabilities_reexport_tools():

--- a/bindings/python/tests/test_schema_sync.py
+++ b/bindings/python/tests/test_schema_sync.py
@@ -126,7 +126,7 @@ def test_event_constants_match():
     assert TOOL_ERROR == "tool:error"
     assert CANCEL_REQUESTED == "cancel:requested"
     assert CANCEL_COMPLETED == "cancel:completed"
-    assert len(ALL_EVENTS) == 41
+    assert len(ALL_EVENTS) == 42
 
 
 def test_hook_result_json_roundtrip():

--- a/crates/amplifier-core/Cargo.toml
+++ b/crates/amplifier-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2021"
 description = "Pure Rust kernel for the Amplifier modular AI agent system"
 license = "MIT"

--- a/crates/amplifier-core/src/events.rs
+++ b/crates/amplifier-core/src/events.rs
@@ -150,6 +150,12 @@ pub const CANCEL_REQUESTED: &str = "cancel:requested";
 /// Cancellation has been finalized, session stopping.
 pub const CANCEL_COMPLETED: &str = "cancel:completed";
 
+// --- Module lifecycle events ---
+
+/// Emitted when a module's on_session_ready() callback raises an exception.
+/// Payload: {module_id: str, error: str}
+pub const MODULE_ON_SESSION_READY_FAILED: &str = "module:on_session_ready_failed";
+
 // --- Aggregate ---
 
 /// All canonical event names, for iteration and validation.
@@ -198,6 +204,7 @@ pub const ALL_EVENTS: &[&str] = &[
     APPROVAL_DENIED,
     CANCEL_REQUESTED,
     CANCEL_COMPLETED,
+    MODULE_ON_SESSION_READY_FAILED,
 ];
 
 #[cfg(test)]
@@ -340,7 +347,7 @@ mod tests {
 
     #[test]
     fn all_events_count() {
-        assert_eq!(ALL_EVENTS.len(), 41, "expected 41 canonical events");
+        assert_eq!(ALL_EVENTS.len(), 42, "expected 42 canonical events");
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-core"
-version = "1.3.3"
+version = "1.4.0"
 description = "Rust kernel with Python bindings for the Amplifier modular AI agent framework"
 license = "MIT"
 readme = "README.md"

--- a/python/amplifier_core/_session_init.py
+++ b/python/amplifier_core/_session_init.py
@@ -66,6 +66,9 @@ async def initialize_session(
         cleanup = await orchestrator_mount(coordinator)
         if cleanup:
             coordinator.register_cleanup(cleanup)
+        # B1 fix: enqueue on_session_ready ONLY after successful mount
+        if on_sr := getattr(orchestrator_mount, "__on_session_ready__", None):
+            loader.enqueue_on_session_ready(on_sr[0], on_sr[1])
     except Exception as e:
         raise RuntimeError(
             f"Cannot initialize without orchestrator: {_safe_exception_str(e)}"
@@ -93,6 +96,9 @@ async def initialize_session(
         cleanup = await context_mount(coordinator)
         if cleanup:
             coordinator.register_cleanup(cleanup)
+        # B1 fix: enqueue on_session_ready ONLY after successful mount
+        if on_sr := getattr(context_mount, "__on_session_ready__", None):
+            loader.enqueue_on_session_ready(on_sr[0], on_sr[1])
     except Exception as e:
         raise RuntimeError(
             f"Cannot initialize without context manager: {_safe_exception_str(e)}"
@@ -151,6 +157,9 @@ async def initialize_session(
             cleanup = await provider_mount(coordinator)
             if cleanup:
                 coordinator.register_cleanup(cleanup)
+            # B1 fix: enqueue on_session_ready ONLY after successful mount
+            if on_sr := getattr(provider_mount, "__on_session_ready__", None):
+                loader.enqueue_on_session_ready(on_sr[0], on_sr[1])
 
             # Multi-instance remapping: if instance_id specified, remap mount name
             if instance_id:
@@ -198,6 +207,9 @@ async def initialize_session(
             cleanup = await tool_mount(coordinator)
             if cleanup:
                 coordinator.register_cleanup(cleanup)
+            # B1 fix: enqueue on_session_ready ONLY after successful mount
+            if on_sr := getattr(tool_mount, "__on_session_ready__", None):
+                loader.enqueue_on_session_ready(on_sr[0], on_sr[1])
         except Exception as e:
             logger.warning(
                 f"Failed to load tool '{module_id}': {_safe_exception_str(e)}",
@@ -220,11 +232,44 @@ async def initialize_session(
             cleanup = await hook_mount(coordinator)
             if cleanup:
                 coordinator.register_cleanup(cleanup)
+            # B1 fix: enqueue on_session_ready ONLY after successful mount
+            if on_sr := getattr(hook_mount, "__on_session_ready__", None):
+                loader.enqueue_on_session_ready(on_sr[0], on_sr[1])
         except Exception as e:
             logger.warning(
                 f"Failed to load hook '{module_id}': {_safe_exception_str(e)}",
                 exc_info=True,
             )
+
+    # Phase 6 — on_session_ready callbacks
+    # Called after ALL modules have been mounted. Each callback receives the
+    # fully-composed coordinator. Failures are non-fatal: caught, logged as
+    # WARNING with exc_info=True, and do not block remaining callbacks.
+    # B4 fix: get_on_session_ready_queue() is a sync method — call it directly.
+    on_session_ready_queue = loader.get_on_session_ready_queue()
+    if on_session_ready_queue:
+        logger.info(
+            f"Dispatching {len(on_session_ready_queue)} on_session_ready callbacks"
+        )
+    for module_id, on_session_ready_fn in on_session_ready_queue:
+        try:
+            await on_session_ready_fn(coordinator)
+        except Exception as e:
+            logger.warning(
+                f"on_session_ready for '{module_id}' raised: {_safe_exception_str(e)}",
+                exc_info=True,
+            )
+            from .events import MODULE_ON_SESSION_READY_FAILED
+            try:
+                await coordinator.hooks.emit(
+                    MODULE_ON_SESSION_READY_FAILED,
+                    {"module_id": module_id, "error": _safe_exception_str(e)},
+                )
+            except Exception:
+                pass  # Event emission failure must not suppress the original warning
+
+    # B7 fix: drain queue after dispatch to prevent double-dispatch on re-use
+    loader.clear_on_session_ready_queue()
 
     # Emit session:fork event if this is a child session
     if parent_id:

--- a/python/amplifier_core/events.py
+++ b/python/amplifier_core/events.py
@@ -60,6 +60,8 @@ from amplifier_core._engine import (
     # Cancellation lifecycle
     CANCEL_REQUESTED,
     CANCEL_COMPLETED,
+    # Module lifecycle events
+    MODULE_ON_SESSION_READY_FAILED,
     ALL_EVENTS,
 )
 
@@ -106,4 +108,5 @@ __all__ = [
     "CANCEL_REQUESTED",
     "CANCEL_COMPLETED",
     "ALL_EVENTS",
+    "MODULE_ON_SESSION_READY_FAILED",
 ]

--- a/python/amplifier_core/loader.py
+++ b/python/amplifier_core/loader.py
@@ -11,6 +11,7 @@ With module source resolution:
 import contextlib
 import importlib
 import importlib.metadata
+import inspect
 import logging
 import os
 import sys
@@ -76,6 +77,7 @@ class ModuleLoader:
         self._search_paths = search_paths
         self._coordinator = coordinator
         self._added_paths: list[str] = []  # Track sys.path additions for cleanup
+        self._on_session_ready_queue: list[tuple[str, Callable]] = []
 
     async def discover(self) -> list[ModuleInfo]:
         """
@@ -208,6 +210,10 @@ class ModuleLoader:
             ):
                 return await fn(coordinator, config or {})
 
+            # B1: propagate __on_session_ready__ to fresh closure
+            if on_sr := getattr(raw_fn, "__on_session_ready__", None):
+                setattr(mount_with_config_cached, "__on_session_ready__", on_sr)
+
             return mount_with_config_cached
 
         try:
@@ -324,6 +330,10 @@ class ModuleLoader:
                 ):
                     return await fn(coordinator, config or {})
 
+                # B1: propagate __on_session_ready__ to closure
+                if on_sr := getattr(raw_fn, "__on_session_ready__", None):
+                    setattr(mount_with_config_ep, "__on_session_ready__", on_sr)
+
                 return mount_with_config_ep
 
             # Try filesystem loading
@@ -335,6 +345,10 @@ class ModuleLoader:
                     coordinator: ModuleCoordinator, fn=raw_fn
                 ):
                     return await fn(coordinator, config or {})
+
+                # B1: propagate __on_session_ready__ to closure
+                if on_sr := getattr(raw_fn, "__on_session_ready__", None):
+                    setattr(mount_with_config_fs, "__on_session_ready__", on_sr)
 
                 return mount_with_config_fs
 
@@ -371,6 +385,10 @@ class ModuleLoader:
             ):
                 return await fn(coordinator, config or {})
 
+            # B1: propagate __on_session_ready__ to closure
+            if on_sr := getattr(raw_fn, "__on_session_ready__", None):
+                setattr(mount_with_config_direct_ep, "__on_session_ready__", on_sr)
+
             return mount_with_config_direct_ep
 
         # Try filesystem — returns raw mount function (no config bound)
@@ -382,6 +400,10 @@ class ModuleLoader:
                 coordinator: ModuleCoordinator, fn=raw_fn
             ):
                 return await fn(coordinator, config or {})
+
+            # B1: propagate __on_session_ready__ to closure
+            if on_sr := getattr(raw_fn, "__on_session_ready__", None):
+                setattr(mount_with_config_direct_fs, "__on_session_ready__", on_sr)
 
             return mount_with_config_direct_fs
 
@@ -401,6 +423,31 @@ class ModuleLoader:
                     # Load the raw mount function (no config binding here)
                     mount_fn = ep.load()
                     logger.info(f"Loaded module '{module_id}' via entry point")
+
+                    # B2 fix: detect on_session_ready from entry-point modules.
+                    # ep.load() returns the mount function directly — no module object.
+                    # Recover the module via mount_fn.__module__ and check for on_session_ready.
+                    # Note: if the mount function lives in a submodule (e.g. amplifier_module_foo.handlers
+                    # rather than amplifier_module_foo), sys.modules.get(__module__) will find the submodule,
+                    # not the top-level package. on_session_ready defined at the top-level package (as is
+                    # conventional) will be missed. Constraint: on_session_ready must be defined in the
+                    # same module as the mount() function, or at the top-level package __init__.py.
+                    module_name = getattr(mount_fn, "__module__", None)
+                    if module_name:
+                        mod = sys.modules.get(module_name)
+                        if mod is None:
+                            with contextlib.suppress(ImportError):
+                                mod = importlib.import_module(module_name)
+                        if mod and hasattr(mod, "on_session_ready"):
+                            fn = mod.on_session_ready
+                            if inspect.iscoroutinefunction(fn):
+                                setattr(mount_fn, "__on_session_ready__", (module_id, fn))
+                            else:
+                                logger.warning(
+                                    f"Module '{module_id}' defines on_session_ready() as sync "
+                                    "— must be async. Skipping."
+                                )
+
                     return mount_fn
 
         except Exception as e:
@@ -421,10 +468,33 @@ class ModuleLoader:
             module_name = f"amplifier_module_{module_id.replace('-', '_')}"
             module = importlib.import_module(module_name)
 
+            # Detect on_session_ready lifecycle hook if present.
+            # B1 fix: do NOT enqueue here — _session_init enqueues after successful mount().
+            # Attach to the raw mount function so load() can propagate it to the closure.
+            if hasattr(module, "on_session_ready"):
+                fn = module.on_session_ready
+                if inspect.iscoroutinefunction(fn):
+                    # Attachment happens below when returning the raw mount fn
+                    pass
+                else:
+                    logger.warning(
+                        f"Module '{module_id}' defines on_session_ready() as sync "
+                        "— must be async. Skipping."
+                    )
+
             # Get the raw mount function (no config binding here)
             if hasattr(module, "mount"):
                 logger.info(f"Loaded module '{module_id}' from filesystem")
-                return module.mount
+                raw_mount = module.mount
+                # B1: attach on_session_ready to the raw function for propagation
+                if hasattr(module, "on_session_ready") and inspect.iscoroutinefunction(
+                    module.on_session_ready
+                ):
+                    raw_mount.__on_session_ready__ = (
+                        module_id,
+                        module.on_session_ready,
+                    )
+                return raw_mount
 
         except Exception as e:
             logger.debug(f"Could not load '{module_id}' from filesystem: {e}")
@@ -908,3 +978,27 @@ class ModuleLoader:
                 # Path already removed or never existed
                 logger.debug(f"Path '{path}' already removed from sys.path")
         self._added_paths.clear()
+
+    def get_on_session_ready_queue(self) -> list[tuple[str, Callable]]:
+        """Return a defensive copy of the on_session_ready lifecycle hook queue.
+
+        Each entry is a ``(module_id, on_session_ready_fn)`` tuple where
+        ``on_session_ready_fn`` is guaranteed to be an async callable.
+        """
+        return list(self._on_session_ready_queue)
+
+    def enqueue_on_session_ready(self, module_id: str, fn: Callable) -> None:
+        """Enqueue an on_session_ready callback. Called by _session_init after successful mount().
+
+        Only async functions should be enqueued; the caller is responsible for the
+        inspect.iscoroutinefunction() check (done at load time in load()).
+        """
+        self._on_session_ready_queue.append((module_id, fn))
+
+    def clear_on_session_ready_queue(self) -> None:
+        """Clear the on_session_ready queue after dispatch.
+
+        Called by _session_init after Phase 6 to drain the queue and prevent
+        double-dispatch on any subsequent re-use of the loader instance.
+        """
+        self._on_session_ready_queue.clear()

--- a/python/amplifier_core/validation/context.py
+++ b/python/amplifier_core/validation/context.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .base import ValidationCheck
 from .base import ValidationResult
+from .structural import check_on_session_ready
 
 
 def _implements_context_manager_interface(obj: Any) -> bool:
@@ -73,6 +74,11 @@ class ContextValidator:
 
         # Check 3: mount() signature is correct
         self._check_mount_signature(result, mount_fn)
+
+        # Check 3.5: on_session_ready() must be async and accept coordinator
+        on_session_ready_check = check_on_session_ready(module)
+        if on_session_ready_check is not None:
+            result.add(on_session_ready_check)
 
         # Check 4: Protocol compliance (requires calling mount)
         await self._check_protocol_compliance(result, mount_fn, config=config)

--- a/python/amplifier_core/validation/hook.py
+++ b/python/amplifier_core/validation/hook.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .base import ValidationCheck
 from .base import ValidationResult
+from .structural import check_on_session_ready
 
 
 def _implements_hook_handler_interface(obj: Any) -> bool:
@@ -64,6 +65,11 @@ class HookValidator:
 
         # Check 3: mount() signature is correct
         self._check_mount_signature(result, mount_fn)
+
+        # Check 3.5: on_session_ready() must be async and accept coordinator
+        on_session_ready_check = check_on_session_ready(module)
+        if on_session_ready_check is not None:
+            result.add(on_session_ready_check)
 
         # Check 4: Protocol compliance (requires calling mount)
         await self._check_protocol_compliance(result, mount_fn, config=config)

--- a/python/amplifier_core/validation/orchestrator.py
+++ b/python/amplifier_core/validation/orchestrator.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .base import ValidationCheck
 from .base import ValidationResult
+from .structural import check_on_session_ready
 
 
 def _implements_orchestrator_interface(obj: Any) -> bool:
@@ -64,6 +65,11 @@ class OrchestratorValidator:
 
         # Check 3: mount() signature is correct
         self._check_mount_signature(result, mount_fn)
+
+        # Check 3.5: on_session_ready() must be async and accept coordinator
+        on_session_ready_check = check_on_session_ready(module)
+        if on_session_ready_check is not None:
+            result.add(on_session_ready_check)
 
         # Check 4: Protocol compliance (requires calling mount)
         await self._check_protocol_compliance(result, mount_fn, config=config)

--- a/python/amplifier_core/validation/provider.py
+++ b/python/amplifier_core/validation/provider.py
@@ -16,6 +16,7 @@ from typing import Any
 from ..models import ProviderInfo
 from .base import ValidationCheck
 from .base import ValidationResult
+from .structural import check_on_session_ready
 
 
 def _implements_provider_interface(obj: Any) -> bool:
@@ -74,6 +75,11 @@ class ProviderValidator:
 
         # Check 3: mount() signature is correct
         self._check_mount_signature(result, mount_fn)
+
+        # Check 3.5: on_session_ready() must be async and accept coordinator
+        on_session_ready_check = check_on_session_ready(module)
+        if on_session_ready_check is not None:
+            result.add(on_session_ready_check)
 
         # Check 4: Protocol compliance (requires calling mount)
         await self._check_protocol_compliance(result, mount_fn, config=config)

--- a/python/amplifier_core/validation/structural/__init__.py
+++ b/python/amplifier_core/validation/structural/__init__.py
@@ -30,6 +30,10 @@ Philosophy:
     - No duplication: Modules just inherit, no copy-paste
 """
 
+import inspect
+from typing import Any
+
+from ..base import ValidationCheck
 from .test_context import ContextStructuralTests
 from .test_hook import HookStructuralTests
 from .test_orchestrator import OrchestratorStructuralTests
@@ -42,4 +46,64 @@ __all__ = [
     "HookStructuralTests",
     "OrchestratorStructuralTests",
     "ContextStructuralTests",
+    "check_on_session_ready",
 ]
+
+
+def check_on_session_ready(module: Any) -> ValidationCheck | None:
+    """Check whether a module's on_session_ready() function, if present, is valid.
+
+    Validates:
+    1. Presence: returns None when on_session_ready is absent (no check needed).
+    2. Async: returns a failing ValidationCheck when on_session_ready exists but
+       is not async (must be ``async def``).
+    3. Arity (B5): returns a failing ValidationCheck when on_session_ready exists,
+       is async, but accepts no positional arguments — the coordinator argument
+       is required.
+
+    Args:
+        module: The imported module object to inspect.
+
+    Returns:
+        None if no issue found, or a ValidationCheck with passed=False describing
+        the first problem encountered.
+    """
+    fn = getattr(module, "on_session_ready", None)
+    if fn is None:
+        return None
+    if not inspect.iscoroutinefunction(fn):
+        return ValidationCheck(
+            name="on_session_ready_async",
+            passed=False,
+            message=(
+                "on_session_ready() must be async: found sync function. "
+                "Use 'async def on_session_ready(coordinator) -> None:'"
+            ),
+            severity="error",
+        )
+    # B5 fix: validate arity — must accept at least one positional arg (coordinator)
+    try:
+        sig = inspect.signature(fn)
+        positional_params = [
+            p
+            for p in sig.parameters.values()
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.POSITIONAL_ONLY,
+            )
+            and p.default is inspect.Parameter.empty
+        ]
+        if len(positional_params) < 1:
+            return ValidationCheck(
+                name="on_session_ready_async",
+                passed=False,
+                message=(
+                    "on_session_ready() must accept a coordinator argument: "
+                    "async def on_session_ready(coordinator) -> None"
+                ),
+                severity="error",
+            )
+    except (ValueError, TypeError):
+        pass  # Can't inspect — let it pass; runtime will catch it
+    return None

--- a/python/amplifier_core/validation/tool.py
+++ b/python/amplifier_core/validation/tool.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .base import ValidationCheck
 from .base import ValidationResult
+from .structural import check_on_session_ready
 
 
 def _implements_tool_interface(obj: Any) -> bool:
@@ -69,6 +70,11 @@ class ToolValidator:
 
         # Check 3: mount() signature is correct
         self._check_mount_signature(result, mount_fn)
+
+        # Check 3.5: on_session_ready() must be async and accept coordinator
+        on_session_ready_check = check_on_session_ready(module)
+        if on_session_ready_check is not None:
+            result.add(on_session_ready_check)
 
         # Check 4: Protocol compliance (requires calling mount)
         await self._check_protocol_compliance(result, mount_fn, config=config)

--- a/tests/test_check_on_session_ready.py
+++ b/tests/test_check_on_session_ready.py
@@ -1,0 +1,308 @@
+"""
+Tests for check_on_session_ready() helper and its integration into validators.
+"""
+
+import types
+import pytest
+
+
+class TestCheckOnSessionReadyFunction:
+    """Tests for the check_on_session_ready() helper function."""
+
+    def test_importable_from_structural(self):
+        """check_on_session_ready must be importable from amplifier_core.validation.structural."""
+        from amplifier_core.validation.structural import check_on_session_ready  # noqa: F401
+
+    def test_in_all_list(self):
+        """check_on_session_ready must be exported in __all__."""
+        import amplifier_core.validation.structural as m
+
+        assert "check_on_session_ready" in m.__all__
+
+    def test_returns_none_when_on_session_ready_absent(self):
+        """Returns None when module has no on_session_ready attribute."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+        result = check_on_session_ready(module)
+        assert result is None
+
+    def test_returns_error_check_when_on_session_ready_not_async(self):
+        """Returns failing ValidationCheck when on_session_ready exists but is not async."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        def on_session_ready():
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is not None
+        assert result.name == "on_session_ready_async"
+        assert result.passed is False
+        assert "async" in result.message.lower()
+        assert result.severity == "error"
+
+    def test_returns_none_when_on_session_ready_is_async_with_coordinator(self):
+        """Returns None when on_session_ready is present, async, and accepts coordinator."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        async def on_session_ready(coordinator):
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is None
+
+    def test_check_name_is_on_session_ready_async(self):
+        """When returning a check, name must be 'on_session_ready_async'."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        def on_session_ready():
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is not None
+        assert result.name == "on_session_ready_async"
+
+    def test_check_severity_is_error(self):
+        """When returning a check, severity must be 'error'."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        def on_session_ready():
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is not None
+        assert result.severity == "error"
+
+    def test_b5_returns_error_when_no_coordinator_arg(self):
+        """B5: Returns failing check when on_session_ready is async but takes no args."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        async def on_session_ready():  # missing coordinator param
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is not None
+        assert result.passed is False
+        assert result.name == "on_session_ready_async"
+        assert "coordinator" in result.message.lower()
+
+    def test_b5_accepts_coordinator_with_default(self):
+        """B5: coordinator with a default value does NOT count (must be required)."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        async def on_session_ready(coordinator=None):  # optional coordinator
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        # coordinator has a default — not required positional; should fail B5 check
+        result = check_on_session_ready(module)
+        assert result is not None
+        assert result.passed is False
+
+    def test_b5_passes_with_extra_kwargs(self):
+        """B5: on_session_ready(coordinator, **kwargs) passes arity check."""
+        from amplifier_core.validation.structural import check_on_session_ready
+
+        module = types.ModuleType("fake_module")
+
+        async def on_session_ready(coordinator, **kwargs):
+            pass
+
+        module.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+
+        result = check_on_session_ready(module)
+        assert result is None
+
+
+class TestCheckOnSessionReadyInValidators:
+    """Tests that all 5 validators call check_on_session_ready and add the result."""
+
+    @pytest.mark.asyncio
+    async def test_hook_validator_catches_sync_on_session_ready(self, tmp_path):
+        """HookValidator includes on_session_ready_async check when on_session_ready is sync."""
+        module_file = tmp_path / "test_hook_sync_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import HookValidator
+
+        validator = HookValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" in check_names
+        on_sr_check = next(
+            c for c in result.checks if c.name == "on_session_ready_async"
+        )
+        assert on_sr_check.passed is False
+
+    @pytest.mark.asyncio
+    async def test_tool_validator_catches_sync_on_session_ready(self, tmp_path):
+        """ToolValidator includes on_session_ready_async check when on_session_ready is sync."""
+        module_file = tmp_path / "test_tool_sync_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import ToolValidator
+
+        validator = ToolValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" in check_names
+        on_sr_check = next(
+            c for c in result.checks if c.name == "on_session_ready_async"
+        )
+        assert on_sr_check.passed is False
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_validator_catches_sync_on_session_ready(self, tmp_path):
+        """OrchestratorValidator includes on_session_ready_async check."""
+        module_file = tmp_path / "test_orch_sync_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import OrchestratorValidator
+
+        validator = OrchestratorValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" in check_names
+        on_sr_check = next(
+            c for c in result.checks if c.name == "on_session_ready_async"
+        )
+        assert on_sr_check.passed is False
+
+    @pytest.mark.asyncio
+    async def test_provider_validator_catches_sync_on_session_ready(self, tmp_path):
+        """ProviderValidator includes on_session_ready_async check."""
+        module_file = tmp_path / "test_provider_sync_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import ProviderValidator
+
+        validator = ProviderValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" in check_names
+        on_sr_check = next(
+            c for c in result.checks if c.name == "on_session_ready_async"
+        )
+        assert on_sr_check.passed is False
+
+    @pytest.mark.asyncio
+    async def test_context_validator_catches_sync_on_session_ready(self, tmp_path):
+        """ContextValidator includes on_session_ready_async check."""
+        module_file = tmp_path / "test_context_sync_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import ContextValidator
+
+        validator = ContextValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" in check_names
+        on_sr_check = next(
+            c for c in result.checks if c.name == "on_session_ready_async"
+        )
+        assert on_sr_check.passed is False
+
+    @pytest.mark.asyncio
+    async def test_hook_validator_no_check_when_on_session_ready_absent(self, tmp_path):
+        """HookValidator does not add check when on_session_ready is absent."""
+        module_file = tmp_path / "test_hook_no_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+""")
+        from amplifier_core.validation import HookValidator
+
+        validator = HookValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" not in check_names
+
+    @pytest.mark.asyncio
+    async def test_hook_validator_no_check_when_on_session_ready_async(self, tmp_path):
+        """HookValidator does not add check when on_session_ready is properly async."""
+        module_file = tmp_path / "test_hook_async_on_session_ready.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+async def on_session_ready(coordinator):
+    pass  # properly async with coordinator arg
+""")
+        from amplifier_core.validation import HookValidator
+
+        validator = HookValidator()
+        result = await validator.validate(str(module_file))
+        check_names = [c.name for c in result.checks]
+        assert "on_session_ready_async" not in check_names
+
+    @pytest.mark.asyncio
+    async def test_check_on_session_ready_appears_after_mount_signature(self, tmp_path):
+        """on_session_ready_async check appears after mount_signature check."""
+        module_file = tmp_path / "test_check_order.py"
+        module_file.write_text("""
+async def mount(coordinator, config):
+    return None
+
+def on_session_ready(coordinator):
+    pass  # sync, should be async
+""")
+        from amplifier_core.validation import HookValidator
+
+        validator = HookValidator()
+        result = await validator.validate(str(module_file))
+
+        check_names = [c.name for c in result.checks]
+        # mount_signature should appear before on_session_ready_async
+        assert "mount_signature" in check_names
+        assert "on_session_ready_async" in check_names
+        sig_idx = check_names.index("mount_signature")
+        osr_idx = check_names.index("on_session_ready_async")
+        assert sig_idx < osr_idx

--- a/tests/test_contracts_lifecycle_section.py
+++ b/tests/test_contracts_lifecycle_section.py
@@ -1,0 +1,364 @@
+"""
+TDD test for 'Module Lifecycle Methods' section in CONTRACTS.md.
+
+Tests verify:
+1. The section exists
+2. It is positioned correctly (between Python-Only Types and Event Constants)
+3. It documents mount() and on_session_ready() with appropriate detail
+4. Contract table contains required rows
+5. 'When to use' guidance is present
+6. Code example is present
+7. Polyglot note is present
+"""
+
+import os
+import re
+
+CONTRACTS_MD_PATH = os.path.join(os.path.dirname(__file__), "..", "CONTRACTS.md")
+
+SECTION_HEADER = "## Module Lifecycle Methods"
+AFTER_SECTION = "## Python-Only Types"
+BEFORE_SECTION = "## Event Constants"
+
+
+def read_doc():
+    with open(CONTRACTS_MD_PATH, "r") as f:
+        return f.read()
+
+
+def get_section_text(content):
+    """Extract the Module Lifecycle Methods section text."""
+    start = content.find(SECTION_HEADER)
+    if start == -1:
+        return None
+    end = content.find("\n## ", start + 1)
+    if end == -1:
+        return content[start:]
+    return content[start:end]
+
+
+# ---------------------------------------------------------------------------
+# Structural / placement tests
+# ---------------------------------------------------------------------------
+
+
+def test_section_exists():
+    """'## Module Lifecycle Methods' section must exist in CONTRACTS.md."""
+    content = read_doc()
+    assert SECTION_HEADER in content, (
+        f"Section '{SECTION_HEADER}' not found in CONTRACTS.md"
+    )
+
+
+def test_section_between_python_only_types_and_event_constants():
+    """Section must appear AFTER Python-Only Types and BEFORE Event Constants."""
+    content = read_doc()
+    lifecycle_pos = content.find(SECTION_HEADER)
+    python_only_pos = content.find("## Python-Only Types")
+    event_constants_pos = content.find("## Event Constants")
+
+    assert lifecycle_pos != -1, f"'{SECTION_HEADER}' not found"
+    assert python_only_pos != -1, "'## Python-Only Types' not found"
+    assert event_constants_pos != -1, "'## Event Constants' not found"
+
+    assert python_only_pos < lifecycle_pos, (
+        "Module Lifecycle Methods must appear AFTER Python-Only Types"
+    )
+    assert lifecycle_pos < event_constants_pos, (
+        "Module Lifecycle Methods must appear BEFORE Event Constants"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content tests: mount() documentation
+# ---------------------------------------------------------------------------
+
+
+def test_mount_method_documented():
+    """Section must document the mount() method."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert "mount" in section, (
+        "mount() method not documented in Module Lifecycle Methods"
+    )
+
+
+def test_mount_is_required():
+    """mount() must be documented as required."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    # Should mention it's required or existing
+    assert re.search(r"\b(required|existing)\b", section, re.IGNORECASE), (
+        "mount() should be documented as required/existing"
+    )
+
+
+def test_mount_signature_documented():
+    """mount(coordinator, config) signature must be present."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    # Should show async def mount with coordinator and config
+    assert re.search(r"mount\s*\(.*coordinator.*config", section), (
+        "mount(coordinator, config) signature not found in section"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content tests: on_session_ready() documentation
+# ---------------------------------------------------------------------------
+
+
+def test_on_session_ready_method_documented():
+    """Section must document the on_session_ready() method."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert "on_session_ready" in section, (
+        "on_session_ready() method not documented in Module Lifecycle Methods"
+    )
+
+
+def test_on_session_ready_is_optional():
+    """on_session_ready() must be documented as optional."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    # Find the part about on_session_ready and check it mentions optional
+    osr_pos = section.find("on_session_ready")
+    assert osr_pos != -1
+    surrounding = section[max(0, osr_pos - 200) : osr_pos + 500]
+    assert "optional" in surrounding.lower(), (
+        "on_session_ready() should be documented as optional"
+    )
+
+
+def test_on_session_ready_signature_documented():
+    """async def on_session_ready(coordinator) -> None signature must be present."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"on_session_ready\s*\(.*coordinator.*\)", section), (
+        "on_session_ready(coordinator) signature not found in section"
+    )
+
+
+def test_on_session_ready_called_after_all_modules_complete_mount():
+    """on_session_ready() must be documented as called after ALL modules complete mount()."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    # Should mention being called after all modules complete mount
+    assert re.search(
+        r"all (modules|phases).*(complete|finish|mount)", section, re.IGNORECASE
+    ) or re.search(r"after all", section, re.IGNORECASE), (
+        "on_session_ready() timing (after all modules complete mount) not documented"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract table tests
+# ---------------------------------------------------------------------------
+
+
+def test_contract_table_has_presence_row():
+    """Contract table must include Presence row (optional)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Pp]resence", section), "Contract table missing 'Presence' row"
+    assert "optional" in section.lower(), (
+        "Contract table 'Presence' row should indicate 'optional'"
+    )
+
+
+def test_contract_table_has_signature_row():
+    """Contract table must include Signature row."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Ss]ignature", section), "Contract table missing 'Signature' row"
+
+
+def test_contract_table_has_async_requirement():
+    """Contract table must document async requirement (sync warns and skips)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"(warn|skip)", section, re.IGNORECASE), (
+        "Contract table should document that sync implementations warn and are skipped"
+    )
+
+
+def test_contract_table_has_return_value_row():
+    """Contract table must include Return value row (ignored)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Rr]eturn", section), "Contract table missing 'Return' row"
+
+
+def test_contract_table_has_exceptions_row():
+    """Contract table must include Exceptions row (non-fatal, logged)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Ee]xception", section), (
+        "Contract table missing 'Exceptions' row"
+    )
+    assert re.search(r"(non-fatal|non fatal|warning|warn)", section, re.IGNORECASE), (
+        "Exceptions should be documented as non-fatal"
+    )
+
+
+def test_contract_table_has_timing_row():
+    """Contract table must include Timing row (before session:fork)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Tt]iming", section), "Contract table missing 'Timing' row"
+    assert "session:fork" in section, "Timing should mention 'session:fork'"
+
+
+def test_contract_table_has_scope_row():
+    """Contract table must include Scope row (Python-only)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Ss]cope", section), "Contract table missing 'Scope' row"
+    assert re.search(r"[Pp]ython.only", section), "Scope should indicate Python-only"
+
+
+# ---------------------------------------------------------------------------
+# 'When to use' section tests
+# ---------------------------------------------------------------------------
+
+
+def test_when_to_use_section_exists():
+    """Section must include 'When to use' guidance."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"[Ww]hen to use", section), (
+        "Section missing 'When to use' guidance"
+    )
+
+
+def test_when_to_use_mentions_cross_module_deps():
+    """'When to use' must mention cross-module dependencies."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(
+        r"(cross.module|cross module|dependencies|dep)", section, re.IGNORECASE
+    ), "'When to use' should mention cross-module dependencies"
+
+
+def test_when_to_use_mentions_dual_path_elimination():
+    """'When to use' must mention dual-path elimination pattern."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"dual.path", section, re.IGNORECASE), (
+        "'When to use' should mention dual-path elimination"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Code example tests
+# ---------------------------------------------------------------------------
+
+
+def test_code_example_exists():
+    """Section must contain a Python code example."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert "```python" in section, "Section missing Python code example"
+
+
+def test_code_example_has_before_after():
+    """Code example must show before/after pattern (dual-path elimination)."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"(before|after|without|with)", section, re.IGNORECASE), (
+        "Code example should show before/after pattern"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Polyglot note tests
+# ---------------------------------------------------------------------------
+
+
+def test_polyglot_note_exists():
+    """Section must include polyglot note about WASM/gRPC/Rust deferral."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    assert re.search(r"(polyglot|WASM|wasm|gRPC|grpc|Rust)", section), (
+        "Section missing polyglot note about WASM/gRPC/Rust deferral"
+    )
+
+
+def test_polyglot_note_mentions_python_only():
+    """Polyglot note must clarify on_session_ready is Python-only."""
+    content = read_doc()
+    section = get_section_text(content)
+    assert section is not None, f"'{SECTION_HEADER}' section not found"
+    # The polyglot note should mention deferral or Python-only scope
+    assert re.search(r"(defer|Python.only|Python only)", section, re.IGNORECASE), (
+        "Polyglot note should clarify Python-only scope or deferral"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main runner for standalone execution
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+
+    tests = [
+        test_section_exists,
+        test_section_between_python_only_types_and_event_constants,
+        test_mount_method_documented,
+        test_mount_is_required,
+        test_mount_signature_documented,
+        test_on_session_ready_method_documented,
+        test_on_session_ready_is_optional,
+        test_on_session_ready_signature_documented,
+        test_on_session_ready_called_after_all_modules_complete_mount,
+        test_contract_table_has_presence_row,
+        test_contract_table_has_signature_row,
+        test_contract_table_has_async_requirement,
+        test_contract_table_has_return_value_row,
+        test_contract_table_has_exceptions_row,
+        test_contract_table_has_timing_row,
+        test_contract_table_has_scope_row,
+        test_when_to_use_section_exists,
+        test_when_to_use_mentions_cross_module_deps,
+        test_when_to_use_mentions_dual_path_elimination,
+        test_code_example_exists,
+        test_code_example_has_before_after,
+        test_polyglot_note_exists,
+        test_polyglot_note_mentions_python_only,
+    ]
+
+    failed = []
+    for test in tests:
+        try:
+            test()
+            print(f"  PASS: {test.__name__}")
+        except AssertionError as e:
+            print(f"  FAIL: {test.__name__}: {e}")
+            failed.append(test.__name__)
+
+    if failed:
+        print(f"\n{len(failed)} test(s) failed.")
+        sys.exit(1)
+    else:
+        print(f"\nAll {len(tests)} tests passed.")

--- a/tests/test_loader_on_session_ready.py
+++ b/tests/test_loader_on_session_ready.py
@@ -1,0 +1,271 @@
+"""Tests for ModuleLoader on_session_ready lifecycle hook detection.
+
+Verifies that _load_filesystem() detects on_session_ready() and attaches it
+to the returned mount function as ``__on_session_ready__`` (B1 attachment
+pattern), rejects sync implementations with a warning, and that
+get_on_session_ready_queue() returns a defensive copy.
+
+Also verifies that on_session_ready is NOT enqueued when mount() fails (B1
+guard: enqueue only after successful mount).
+"""
+
+import inspect
+import logging
+import types
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from amplifier_core.loader import ModuleLoader
+
+
+def _make_module(
+    *,
+    has_mount: bool = True,
+    has_on_session_ready: bool = False,
+    on_session_ready_async: bool = True,
+) -> types.ModuleType:
+    """Create a fake Python module with configurable lifecycle functions."""
+    mod = types.ModuleType("amplifier_module_fake")
+
+    if has_mount:
+
+        async def mount(coordinator, config):
+            return None
+
+        mod.mount = mount  # type: ignore[attr-defined]
+
+    if has_on_session_ready:
+        if on_session_ready_async:
+
+            async def on_session_ready(coordinator):
+                pass
+
+            mod.on_session_ready = on_session_ready  # type: ignore[attr-defined]
+        else:
+
+            def on_session_ready_sync(coordinator):
+                pass
+
+            mod.on_session_ready = on_session_ready_sync  # type: ignore[attr-defined]
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests — queue (get_on_session_ready_queue / _on_session_ready_queue)
+# ---------------------------------------------------------------------------
+
+
+def test_queue_empty_initially():
+    """New loader has an empty on_session_ready queue."""
+    loader = ModuleLoader()
+    assert loader.get_on_session_ready_queue() == []
+
+
+def test_get_on_session_ready_queue_returns_defensive_copy():
+    """Mutating the returned list does not affect the internal queue."""
+    loader = ModuleLoader()
+
+    async def on_session_ready(coordinator):
+        pass
+
+    # Directly append to the internal queue (simulating post-mount state)
+    loader._on_session_ready_queue.append(("mod-a", on_session_ready))
+
+    copy = loader.get_on_session_ready_queue()
+    copy.clear()  # Mutate the returned copy
+
+    assert len(loader.get_on_session_ready_queue()) == 1, "Internal queue must be unaffected"
+
+
+def test_clear_on_session_ready_queue():
+    """clear_on_session_ready_queue() drains the internal queue."""
+    loader = ModuleLoader()
+
+    async def on_session_ready(coordinator):
+        pass
+
+    loader._on_session_ready_queue.append(("mod-a", on_session_ready))
+    assert len(loader._on_session_ready_queue) == 1
+
+    loader.clear_on_session_ready_queue()
+    assert loader._on_session_ready_queue == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — B1 attachment pattern via _load_filesystem()
+# ---------------------------------------------------------------------------
+
+
+def test_async_on_session_ready_is_attached():
+    """_load_filesystem attaches __on_session_ready__ to the returned mount fn."""
+    loader = ModuleLoader()
+    fake_mod = _make_module(
+        has_mount=True, has_on_session_ready=True, on_session_ready_async=True
+    )
+
+    with patch("importlib.import_module", return_value=fake_mod):
+        result = loader._load_filesystem("fake")
+
+    assert result is not None, "mount function should have been returned"
+    on_sr = getattr(result, "__on_session_ready__", None)
+    assert on_sr is not None, "mount fn must have __on_session_ready__ attribute"
+    assert on_sr[0] == "fake"
+    assert inspect.iscoroutinefunction(on_sr[1])
+
+
+def test_async_on_session_ready_not_in_queue_until_session_init():
+    """_load_filesystem does NOT directly populate _on_session_ready_queue (B1)."""
+    loader = ModuleLoader()
+    fake_mod = _make_module(
+        has_mount=True, has_on_session_ready=True, on_session_ready_async=True
+    )
+
+    with patch("importlib.import_module", return_value=fake_mod):
+        loader._load_filesystem("fake")
+
+    # After _load_filesystem, queue must be empty — session_init populates it
+    assert loader.get_on_session_ready_queue() == [], (
+        "_load_filesystem must not populate the queue (B1 fix: session_init does it)"
+    )
+
+
+def test_no_on_session_ready_no_attachment():
+    """_load_filesystem does not attach __on_session_ready__ when absent."""
+    loader = ModuleLoader()
+    fake_mod = _make_module(has_mount=True, has_on_session_ready=False)
+
+    with patch("importlib.import_module", return_value=fake_mod):
+        result = loader._load_filesystem("plain")
+
+    assert result is not None
+    assert getattr(result, "__on_session_ready__", None) is None
+
+
+def test_sync_on_session_ready_warns_and_not_attached(caplog):
+    """_load_filesystem warns and does NOT attach sync on_session_ready."""
+    loader = ModuleLoader()
+    fake_mod = _make_module(
+        has_mount=True, has_on_session_ready=True, on_session_ready_async=False
+    )
+
+    with (
+        patch("importlib.import_module", return_value=fake_mod),
+        caplog.at_level(logging.WARNING, logger="amplifier_core.loader"),
+    ):
+        result = loader._load_filesystem("sync-mod")
+
+    assert result is not None
+    assert getattr(result, "__on_session_ready__", None) is None
+    assert "sync" in caplog.text.lower() or "async" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — B1: on_session_ready does NOT fire when mount() fails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_not_enqueued_when_mount_fails():
+    """on_session_ready is NOT queued when mount() raises — enqueue only after success."""
+    from amplifier_core._session_init import initialize_session
+
+    did_fire = []
+
+    async def on_session_ready(coordinator):
+        did_fire.append(True)
+
+    # A mount function that raises, but has on_session_ready attached
+    async def failing_mount(coordinator):
+        raise RuntimeError("mount failed")
+
+    failing_mount.__on_session_ready__ = ("failing-module", on_session_ready)
+
+    mock_loader = MagicMock(spec=ModuleLoader)
+    # Return the failing mount for every call (orchestrator fails → session raises)
+    mock_loader.load = AsyncMock(return_value=failing_mount)
+    mock_loader._on_session_ready_queue = []
+    mock_loader.get_on_session_ready_queue = MagicMock(
+        side_effect=lambda: list(mock_loader._on_session_ready_queue)
+    )
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.loader = mock_loader
+    mock_coordinator.register_cleanup = MagicMock()
+    mock_coordinator.hooks = MagicMock()
+    mock_coordinator.hooks.emit = AsyncMock()
+
+    config = {
+        "session": {"orchestrator": "loop-basic", "context": "context-simple"},
+        "providers": [],
+        "tools": [],
+        "hooks": [],
+    }
+
+    # Orchestrator failure is fatal — session init will raise
+    with pytest.raises(RuntimeError, match="Cannot initialize without orchestrator"):
+        await initialize_session(config, mock_coordinator, "test-session", None)
+
+    # on_session_ready must NOT have fired
+    assert did_fire == [], "on_session_ready fired despite mount() failure"
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_not_enqueued_for_failed_tool_mount():
+    """Tool mount() failure skips on_session_ready enqueue for that module."""
+    did_fire = []
+
+    async def on_session_ready_for_failing_tool(coordinator):
+        did_fire.append("bad-tool")
+
+    async def failing_tool_mount(coordinator):
+        raise RuntimeError("tool mount failed")
+
+    failing_tool_mount.__on_session_ready__ = (
+        "bad-tool",
+        on_session_ready_for_failing_tool,
+    )
+
+    async def good_orchestrator_mount(coordinator):
+        return None
+
+    async def good_context_mount(coordinator):
+        return None
+
+    # Loader returns good mounts for required modules, failing mount for tool
+    async def load_side_effect(module_id, config=None, source_hint=None, coordinator=None):
+        if module_id == "loop-basic":
+            return good_orchestrator_mount
+        if module_id == "context-simple":
+            return good_context_mount
+        return failing_tool_mount
+
+    mock_loader = MagicMock(spec=ModuleLoader)
+    mock_loader.load = AsyncMock(side_effect=load_side_effect)
+    mock_loader._on_session_ready_queue = []
+    mock_loader.get_on_session_ready_queue = MagicMock(
+        side_effect=lambda: list(mock_loader._on_session_ready_queue)
+    )
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.loader = mock_loader
+    mock_coordinator.register_cleanup = MagicMock()
+    mock_coordinator.hooks = MagicMock()
+    mock_coordinator.hooks.emit = AsyncMock()
+
+    config = {
+        "session": {"orchestrator": "loop-basic", "context": "context-simple"},
+        "providers": [],
+        "tools": [{"module": "bad-tool"}],
+        "hooks": [],
+    }
+
+    from amplifier_core._session_init import initialize_session
+
+    await initialize_session(config, mock_coordinator, "test-session", None)
+
+    # on_session_ready for bad-tool must NOT have fired
+    assert did_fire == []

--- a/tests/test_multi_instance.py
+++ b/tests/test_multi_instance.py
@@ -8,7 +8,9 @@ Covers both session init paths:
 
 import pytest
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
+from amplifier_core.loader import ModuleLoader
 from amplifier_core.session import AmplifierSession as PyAmplifierSession
 from amplifier_core._session_init import initialize_session
 from amplifier_core.testing import MockCoordinator
@@ -32,13 +34,20 @@ def _make_provider_mount_fn(default_name: str, provider_instance=None):
 
 
 def _make_loader(module_to_mount_fn: dict):
-    """Return a mock loader whose load() returns the configured mount function."""
-    loader = AsyncMock()
+    """Return a mock loader whose load() returns the configured mount function.
+
+    B4 fix: use MagicMock (not AsyncMock) so get_on_session_ready_queue() returns
+    a plain list rather than a coroutine, which is required after removing the
+    coroutine guard from _session_init.py.
+    """
 
     async def _load(module_id, config=None, source_hint=None, coordinator=None):
         return module_to_mount_fn[module_id]
 
-    loader.load.side_effect = _load
+    loader = MagicMock(spec=ModuleLoader)
+    loader.load = AsyncMock(side_effect=_load)
+    loader.get_on_session_ready_queue = MagicMock(return_value=[])
+    loader._on_session_ready_queue = []
     return loader
 
 
@@ -155,7 +164,9 @@ async def test_multi_instance_providers_both_mounted():
 
     call_count = {"n": 0}
 
-    async def load_side_effect(module_id, config=None, source_hint=None, coordinator=None):
+    async def load_side_effect(
+        module_id, config=None, source_hint=None, coordinator=None
+    ):
         if module_id == "loop-basic":
             return AsyncMock(return_value=None)
         if module_id == "context-simple":
@@ -165,8 +176,10 @@ async def test_multi_instance_providers_both_mounted():
             return mount_fn_a if call_count["n"] == 1 else mount_fn_b
         raise ValueError(f"Unexpected module: {module_id}")
 
-    loader = AsyncMock()
-    loader.load.side_effect = load_side_effect
+    loader = MagicMock(spec=ModuleLoader)
+    loader.load = AsyncMock(side_effect=load_side_effect)
+    loader.get_on_session_ready_queue = MagicMock(return_value=[])
+    loader._on_session_ready_queue = []
 
     config = {
         "session": {"orchestrator": "loop-basic", "context": "context-simple"},
@@ -289,7 +302,9 @@ async def test_duplicate_module_with_instance_id_passes():
         await coord.mount("providers", provider_b, name="mock")
         return None
 
-    async def load_side_effect(module_id, config=None, source_hint=None, coordinator=None):
+    async def load_side_effect(
+        module_id, config=None, source_hint=None, coordinator=None
+    ):
         if module_id == "loop-basic":
             return AsyncMock(return_value=None)
         if module_id == "context-simple":
@@ -299,8 +314,10 @@ async def test_duplicate_module_with_instance_id_passes():
             return mount_fn_a if call_count["n"] == 1 else mount_fn_b
         raise ValueError(f"Unexpected module: {module_id}")
 
-    loader = AsyncMock()
-    loader.load.side_effect = load_side_effect
+    loader = MagicMock(spec=ModuleLoader)
+    loader.load = AsyncMock(side_effect=load_side_effect)
+    loader.get_on_session_ready_queue = MagicMock(return_value=[])
+    loader._on_session_ready_queue = []
 
     config = {
         "session": {"orchestrator": "loop-basic", "context": "context-simple"},
@@ -367,7 +384,9 @@ async def test_duplicate_module_one_missing_instance_id_allowed():
         await coord.mount("providers", named_instance, name="mock")
         return None
 
-    async def load_side_effect(module_id, config=None, source_hint=None, coordinator=None):
+    async def load_side_effect(
+        module_id, config=None, source_hint=None, coordinator=None
+    ):
         if module_id == "loop-basic":
             return AsyncMock(return_value=None)
         if module_id == "context-simple":
@@ -377,8 +396,10 @@ async def test_duplicate_module_one_missing_instance_id_allowed():
             return mount_fn_default if call_count["n"] == 1 else mount_fn_named
         raise ValueError(f"Unexpected module: {module_id}")
 
-    loader = AsyncMock()
-    loader.load.side_effect = load_side_effect
+    loader = MagicMock(spec=ModuleLoader)
+    loader.load = AsyncMock(side_effect=load_side_effect)
+    loader.get_on_session_ready_queue = MagicMock(return_value=[])
+    loader._on_session_ready_queue = []
 
     config = {
         "session": {"orchestrator": "loop-basic", "context": "context-simple"},
@@ -429,7 +450,9 @@ async def test_mixed_instance_id_preserves_default_entry():
 
     call_count = {"n": 0}
 
-    async def load_side_effect(module_id, config=None, source_hint=None, coordinator=None):
+    async def load_side_effect(
+        module_id, config=None, source_hint=None, coordinator=None
+    ):
         if module_id == "loop-basic":
             return AsyncMock(return_value=None)
         if module_id == "context-simple":
@@ -439,8 +462,10 @@ async def test_mixed_instance_id_preserves_default_entry():
             return mount_fn_first if call_count["n"] == 1 else mount_fn_second
         raise ValueError(f"Unexpected module: {module_id}")
 
-    loader = AsyncMock()
-    loader.load.side_effect = load_side_effect
+    loader = MagicMock(spec=ModuleLoader)
+    loader.load = AsyncMock(side_effect=load_side_effect)
+    loader.get_on_session_ready_queue = MagicMock(return_value=[])
+    loader._on_session_ready_queue = []
 
     config = {
         "session": {"orchestrator": "loop-basic", "context": "context-simple"},

--- a/tests/test_session_init_on_session_ready.py
+++ b/tests/test_session_init_on_session_ready.py
@@ -1,0 +1,185 @@
+"""Tests verifying Phase 6 on_session_ready() dispatch in initialize_session().
+
+Phase 6 should call loader.get_on_session_ready_queue() after all modules are
+loaded and invoke each on_session_ready callback with the coordinator.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from amplifier_core._session_init import initialize_session
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+_MINIMAL_CONFIG = {
+    "session": {
+        "orchestrator": "loop-basic",
+        "context": "context-simple",
+    },
+    "providers": [],
+    "tools": [],
+    "hooks": [],
+}
+
+
+def _make_mocks(on_session_ready_queue):
+    """Build a mock loader + coordinator with a configurable on_session_ready_queue.
+
+    Args:
+        on_session_ready_queue: List of (module_id, on_session_ready_fn) tuples
+            returned by loader.get_on_session_ready_queue().
+
+    Returns:
+        (mock_loader, mock_coordinator) tuple.
+    """
+    # mount function returned by loader.load() — no cleanup
+    mock_mount_fn = AsyncMock(return_value=None)
+
+    mock_loader = MagicMock()
+    mock_loader.load = AsyncMock(return_value=mock_mount_fn)
+    # Sync mock — B4 fix removes coroutine guard; this must be a plain MagicMock
+    mock_loader.get_on_session_ready_queue = MagicMock(
+        return_value=on_session_ready_queue
+    )
+    # Provide a real list so _session_init can append/clear without error
+    mock_loader._on_session_ready_queue = []
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.loader = mock_loader
+    # register_cleanup is synchronous
+    mock_coordinator.register_cleanup = MagicMock()
+    # hooks.emit is async
+    mock_coordinator.hooks = MagicMock()
+    mock_coordinator.hooks.emit = AsyncMock()
+
+    return mock_loader, mock_coordinator
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_called_after_all_phases():
+    """get_on_session_ready_queue is called once and on_session_ready callbacks are invoked."""
+    on_session_ready_cb = AsyncMock()
+    queue = [("test-module", on_session_ready_cb)]
+
+    mock_loader, mock_coordinator = _make_mocks(queue)
+
+    await initialize_session(
+        _MINIMAL_CONFIG,
+        mock_coordinator,
+        session_id="test-session",
+        parent_id=None,
+    )
+
+    # Phase 6 must call get_on_session_ready_queue exactly once
+    mock_loader.get_on_session_ready_queue.assert_called_once()
+    # The on_session_ready callback must be invoked with the coordinator
+    on_session_ready_cb.assert_called_once_with(mock_coordinator)
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_failure_is_nonfatal():
+    """A failing on_session_ready does not prevent other on_session_ready calls."""
+    results = []
+
+    async def failing_on_session_ready(coordinator):
+        raise RuntimeError("on_session_ready failed intentionally")
+
+    async def succeeding_on_session_ready(coordinator):
+        results.append("success")
+
+    queue = [
+        ("mod-a", failing_on_session_ready),
+        ("mod-b", succeeding_on_session_ready),
+    ]
+
+    mock_loader, mock_coordinator = _make_mocks(queue)
+
+    # initialize_session must not raise even though the first on_session_ready fails
+    await initialize_session(
+        _MINIMAL_CONFIG,
+        mock_coordinator,
+        session_id="test-session",
+        parent_id=None,
+    )
+
+    # The second callback must still have run
+    assert "success" in results
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_failure_emits_event():
+    """A failing on_session_ready() emits module:on_session_ready_failed event."""
+    from amplifier_core.events import MODULE_ON_SESSION_READY_FAILED
+
+    emitted_events = []
+
+    async def failing_on_sr(coordinator):
+        raise RuntimeError("intentional failure")
+
+    mock_loader, mock_coordinator = _make_mocks([("failing-module", failing_on_sr)])
+
+    async def tracking_emit(event, payload):
+        emitted_events.append((event, payload))
+
+    mock_coordinator.hooks.emit = AsyncMock(side_effect=tracking_emit)
+
+    await initialize_session(
+        _MINIMAL_CONFIG,
+        mock_coordinator,
+        session_id="test-session",
+        parent_id=None,
+    )
+
+    # Check the failure event was emitted
+    failure_events = [(e, p) for e, p in emitted_events if e == MODULE_ON_SESSION_READY_FAILED]
+    assert len(failure_events) == 1
+    assert failure_events[0][1]["module_id"] == "failing-module"
+    assert "intentional failure" in failure_events[0][1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_on_session_ready_runs_before_session_fork():
+    """on_session_ready completes before session:fork is emitted."""
+    from amplifier_core.events import SESSION_FORK
+
+    event_order = []
+
+    async def tracking_on_session_ready(coordinator):
+        event_order.append("on_session_ready")
+
+    queue = [("track-mod", tracking_on_session_ready)]
+
+    mock_loader, mock_coordinator = _make_mocks(queue)
+
+    # Wrap the mock emit so we can observe when SESSION_FORK fires
+    original_emit = mock_coordinator.hooks.emit
+
+    async def tracking_emit(event, payload):
+        if event == SESSION_FORK:
+            event_order.append("session:fork")
+        return await original_emit(event, payload)
+
+    mock_coordinator.hooks.emit = tracking_emit
+
+    # Pass parent_id to trigger the session:fork path
+    await initialize_session(
+        _MINIMAL_CONFIG,
+        mock_coordinator,
+        session_id="test-session",
+        parent_id="parent-session",
+    )
+
+    assert "on_session_ready" in event_order, "on_session_ready not called"
+    assert event_order.index("on_session_ready") < event_order.index("session:fork"), (
+        "on_session_ready must run before session:fork is emitted"
+    )


### PR DESCRIPTION
## Summary

Adds `async def on_session_ready(coordinator) -> None` — an optional second lifecycle method for modules, called once after **all modules across all phases** have completed `mount()`. The coordinator is fully composed at this point: all providers, tools, hooks, capabilities, and contributions are registered and visible.

## Problem

Every module's `mount()` runs while the coordinator is only partially composed. This creates defensive patterns:

- **Dual-path initialization** — register event handler *and* check if capability already present, because ordering is unknown
- **Triple-path event discovery** — three fallback mechanisms because no single path is reliable at mount time
- **Ordering assumptions in code comments** — fragile, undocumented dependencies between module types

**Measured production impact:** Without `on_session_ready`, hooks that need to subscribe to events contributed by tools must either make ordering assumptions (fragile) or maintain defensive dual-path checks (complex).

## Solution

A new Phase 6 in `initialize_session()` — dispatched after the hooks loop, before `session:fork` — calls each module's `on_session_ready(coordinator)` in mount order. Modules that do not define it are silently skipped.

## Implementation

**`loader.py`**
- `__on_session_ready__` attribute attached to mount closure at load time (both `_load_filesystem` and `_load_entry_point` paths)
- Enqueue moves to `_session_init.py` and fires only after each `mount()` succeeds — failed mounts do not enqueue `on_session_ready`
- `get_on_session_ready_queue()` / `clear_on_session_ready_queue()` accessor methods

**`_session_init.py`**
- Phase 6 dispatch loop after hooks, before `session:fork`
- Non-fatal per-module `try/except`; remaining callbacks run if one raises
- Queue drained after dispatch

**`validation/structural/`**
- `check_on_session_ready()` validates async-ness **and** arity (coordinator arg required)
- Wired into all 5 type validators (hook, tool, orchestrator, provider, context)

**`CONTRACTS.md`**
- Full contract: signature, return value, fork behaviour, dispatch ordering, failure semantics
- No kernel-enforced timeout (documented absence)
- Correct coordinator API in examples (`coordinator.get("tools")`)
- Session-scoped pattern replaces unsafe process-global example
- Canonical adopter example: event subscription after full composition

## Contract

```python
async def on_session_ready(coordinator) -> None:
    """Optional. Called after ALL modules have completed mount().

    The coordinator is fully composed: all providers, tools, hooks,
    capabilities, and contributions are registered and visible.
    Return value is ignored. Exceptions are non-fatal — logged as
    warnings with exc_info=True; remaining callbacks still run.
    """
```

## Design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Signature | `coordinator` only, no `config` | Config received in `mount()`; re-passing encourages deferred config processing |
| Async | Required | Sync functions logged as warning and skipped; enforced at load and validation time |
| Error handling | Non-fatal, per-module isolation | Consistent with tool/hook mount failure policy |
| Collection | Loader attachment + `_session_init` enqueue | Enqueue after mount success prevents firing on failed modules |
| Scope | Python-only | WASM/gRPC/Rust sidecar require `DidMount` in `ModuleLifecycle` proto + Rust engine changes; deferred until needed |

## Tests

```
tests/test_loader_on_session_ready.py         5 passed  — queue collection, async enforcement, defensive copy
tests/test_session_init_on_session_ready.py   3 passed  — dispatch order, non-fatal isolation, before session:fork
tests/test_check_on_session_ready.py         15 passed  — validation rules, arity check, 5 validator integrations
tests/test_contracts_lifecycle_section.py    23 passed  — CONTRACTS.md content verification
tests/test_multi_instance.py                  9 passed  — no regression from mock fix (MagicMock(spec=ModuleLoader))
────────────────────────────────────────────────────────────────────────────
Total: 55 new/updated tests, 0 regressions
```

## Commits

| Hash | Message |
|------|---------|
| `838b22b` | `feat(lifecycle): add on_session_ready() post-composition lifecycle hook` |
| `a56e526` | `docs(contracts): document on_session_ready() contract` |