### PR TITLE
docs(contracts): add normative llm:response.usage schema

### DIFF
--- a/docs/contracts/PROVIDER_CONTRACT.md
+++ b/docs/contracts/PROVIDER_CONTRACT.md
@@ -179,11 +179,12 @@ Providers **MUST** emit `llm:response` with the following `usage` payload. Key n
 |-----|------|----------|-------------|
 | `input_tokens` | `int` | **MUST** | Total input tokens — gross total (fresh + cache_read combined) |
 | `output_tokens` | `int` | **MUST** | Total output tokens generated |
-| `total_tokens` | `int` | SHOULD | Sum of `input_tokens` + `output_tokens`; derivable but present in kernel `Usage` model — omitting it from the event payload breaks consumers that read it from there |
 | `cache_read_tokens` | `int` | SHOULD (when non-zero) | Tokens served from prompt cache |
 | `cache_write_tokens` | `int` | SHOULD (when non-zero) | Tokens written to prompt cache (billed on top of gross) |
 
 **DO NOT use:** `"input"`, `"output"`, `"input_tokens_used"`, `"completion_tokens"`, or any other variant. These break consumers silently.
+
+`total_tokens` is not included in the event payload. Consumers that need it should read `usage.total_tokens` from the kernel `Usage` model (`chat_response.usage.total_tokens`), where it is always present.
 
 **Reference emit pattern** (build `ChatResponse` before emitting):
 

--- a/docs/contracts/PROVIDER_CONTRACT.md
+++ b/docs/contracts/PROVIDER_CONTRACT.md
@@ -171,6 +171,44 @@ coordinator.register_contributor(
 
 See [CONTRIBUTION_CHANNELS.md](../specs/CONTRIBUTION_CHANNELS.md) for the pattern.
 
+### `llm:response` Event — `usage` Payload Schema
+
+Providers **MUST** emit `llm:response` with the following `usage` payload. Key names are normative — derived from the kernel `Usage` struct (`crates/amplifier-core/src/messages.rs`):
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `input_tokens` | `int` | **MUST** | Total input tokens — gross total (fresh + cache_read combined) |
+| `output_tokens` | `int` | **MUST** | Total output tokens generated |
+| `cache_read_tokens` | `int` | SHOULD (when non-zero) | Tokens served from prompt cache |
+| `cache_write_tokens` | `int` | SHOULD (when non-zero) | Tokens written to prompt cache (billed on top of gross) |
+
+**DO NOT use:** `"input"`, `"output"`, `"input_tokens_used"`, `"completion_tokens"`, or any other variant. These break consumers silently.
+
+**Reference emit pattern** (build `ChatResponse` before emitting):
+
+```python
+chat_response = self._convert_to_chat_response(response)  # build first
+
+event_usage: dict[str, Any] = {
+    "input_tokens": chat_response.usage.input_tokens,
+    "output_tokens": chat_response.usage.output_tokens,
+}
+if chat_response.usage.cache_read_tokens is not None:
+    event_usage["cache_read_tokens"] = chat_response.usage.cache_read_tokens
+if chat_response.usage.cache_write_tokens is not None:
+    event_usage["cache_write_tokens"] = chat_response.usage.cache_write_tokens
+
+await coordinator.hooks.emit("llm:response", {
+    "provider": self.name,
+    "model": model,
+    "status": "ok",
+    "duration_ms": elapsed_ms,
+    "usage": event_usage,
+})
+
+return chat_response  # return the already-built response
+```
+
 ---
 
 ## Canonical Example

--- a/docs/contracts/PROVIDER_CONTRACT.md
+++ b/docs/contracts/PROVIDER_CONTRACT.md
@@ -184,7 +184,7 @@ Providers **MUST** emit `llm:response` with the following `usage` payload. Key n
 
 **DO NOT use:** `"input"`, `"output"`, `"input_tokens_used"`, `"completion_tokens"`, or any other variant. These break consumers silently.
 
-`total_tokens` is not included in the event payload. Consumers that need it should read `usage.total_tokens` from the kernel `Usage` model (`chat_response.usage.total_tokens`), where it is always present.
+`total_tokens` is not included in the event payload. Consumers that need it can derive it as `input_tokens + output_tokens` from the event `usage` dict.
 
 **Reference emit pattern** (build `ChatResponse` before emitting):
 

--- a/docs/contracts/PROVIDER_CONTRACT.md
+++ b/docs/contracts/PROVIDER_CONTRACT.md
@@ -179,6 +179,7 @@ Providers **MUST** emit `llm:response` with the following `usage` payload. Key n
 |-----|------|----------|-------------|
 | `input_tokens` | `int` | **MUST** | Total input tokens — gross total (fresh + cache_read combined) |
 | `output_tokens` | `int` | **MUST** | Total output tokens generated |
+| `total_tokens` | `int` | SHOULD | Sum of `input_tokens` + `output_tokens`; derivable but present in kernel `Usage` model — omitting it from the event payload breaks consumers that read it from there |
 | `cache_read_tokens` | `int` | SHOULD (when non-zero) | Tokens served from prompt cache |
 | `cache_write_tokens` | `int` | SHOULD (when non-zero) | Tokens written to prompt cache (billed on top of gross) |
 


### PR DESCRIPTION
## What

Adds a normative `llm:response.usage` payload schema to `PROVIDER_CONTRACT.md` under the Observability section, pinning the required key names to match the kernel `Usage` struct.

## Why

Without a normative schema, the M0 sweep fixes are pattern-by-example only. The next provider author could re-introduce `"input"` / `"output"` and silently break all `llm:response` consumers (e.g. `hooks-streaming-ui`). This section makes the correct key names non-ambiguous and cites the authoritative Rust source.

## What's added

- Schema table: `input_tokens` (MUST), `output_tokens` (MUST), `cache_read_tokens` (SHOULD), `cache_write_tokens` (SHOULD)
- Explicit anti-pattern list: `"input"`, `"output"`, `"input_tokens_used"`, `"completion_tokens"`
- Reference emit pattern showing build-before-emit ordering
- Cites `crates/amplifier-core/src/messages.rs` as source of truth

Requested in microsoft-amplifier/amplifier-support#221 as part of the M0 cost-management initiative.