### PR TITLE
fix: Decimal JSON serialization for Usage.cost_usd — required for M2 cost stamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "amplifier-core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "log",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "amplifier-core-py"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "amplifier-core",
  "log",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core-py"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "PyO3 bridge for amplifier-core Rust kernel"
 license = "MIT"

--- a/bindings/python/tests/test_cost_models.py
+++ b/bindings/python/tests/test_cost_models.py
@@ -74,14 +74,12 @@ class TestUsageCostUsd:
         assert unknown.cost_usd != free.cost_usd
 
     def test_model_dump_serializes_cost_usd_as_string(self):
-        """model_dump() serializes cost_usd as a JSON-safe string.
+        """model_dump() emits cost_usd as a JSON-safe string in every mode.
 
-        Per @field_serializer(when_used='always') on Usage.cost_usd, BOTH
-        plain model_dump() and model_dump(mode='json') emit string. This
-        ensures every orchestrator's `event_data["usage"] = response.usage
-        .model_dump()` produces JSON-safe payloads automatically.
-
-        Direct attribute access still returns Decimal for in-memory math.
+        The model carries its own JSON-safety guarantee: callers can dump
+        and json.dumps the result without specifying mode='json' or providing
+        a default= encoder. Direct attribute access still returns Decimal —
+        monetary arithmetic in memory, JSON-safe strings at boundaries.
         """
         usage = Usage(
             input_tokens=100,

--- a/bindings/python/tests/test_cost_models.py
+++ b/bindings/python/tests/test_cost_models.py
@@ -73,8 +73,16 @@ class TestUsageCostUsd:
         assert free.cost_usd == Decimal("0")
         assert unknown.cost_usd != free.cost_usd
 
-    def test_model_dump_includes_cost_usd_as_decimal(self):
-        """model_dump() should include cost_usd as Decimal (not string, not float)."""
+    def test_model_dump_serializes_cost_usd_as_string(self):
+        """model_dump() serializes cost_usd as a JSON-safe string.
+
+        Per @field_serializer(when_used='always') on Usage.cost_usd, BOTH
+        plain model_dump() and model_dump(mode='json') emit string. This
+        ensures every orchestrator's `event_data["usage"] = response.usage
+        .model_dump()` produces JSON-safe payloads automatically.
+
+        Direct attribute access still returns Decimal for in-memory math.
+        """
         usage = Usage(
             input_tokens=100,
             output_tokens=50,
@@ -83,7 +91,10 @@ class TestUsageCostUsd:
         )
         dumped = usage.model_dump()
         assert "cost_usd" in dumped
-        assert isinstance(dumped["cost_usd"], Decimal)
+        assert isinstance(dumped["cost_usd"], str)
+        assert dumped["cost_usd"] == "0.047"
+        # Direct attribute access still returns Decimal:
+        assert isinstance(usage.cost_usd, Decimal)
 
     def test_model_dump_json_mode_serializes_cost_usd_as_string(self):
         """model_dump(mode='json') serializes Decimal as string for JSON safety."""
@@ -125,6 +136,7 @@ class TestSessionStatusCostUsd:
         assert "cost_usd" in d
         assert isinstance(d["cost_usd"], str)
         assert d["cost_usd"] == "2.50"
+
 
 class TestSchemaSync:
     def test_session_status_schema_has_cost_usd(self):

--- a/crates/amplifier-core/Cargo.toml
+++ b/crates/amplifier-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "Pure Rust kernel for the Amplifier modular AI agent system"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-core"
-version = "1.5.0"
+version = "1.5.1"
 description = "Rust kernel with Python bindings for the Amplifier modular AI agent framework"
 license = "MIT"
 readme = "README.md"

--- a/python/amplifier_core/__init__.py
+++ b/python/amplifier_core/__init__.py
@@ -6,7 +6,7 @@ extension module. Submodule paths (e.g. `from amplifier_core.session import
 AmplifierSession`) still give the pure-Python implementations.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 # --- Rust-backed primary types (THE SWITCHOVER) ---
 # These four were previously imported from their Python submodules.

--- a/python/amplifier_core/message_models.py
+++ b/python/amplifier_core/message_models.py
@@ -24,6 +24,7 @@ from typing import Union
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_serializer
 from pydantic import field_validator
 
 
@@ -263,6 +264,18 @@ class Usage(BaseModel):
                 "Use Decimal('0.047') — floats lose monetary precision."
             )
         return v
+
+    @field_serializer("cost_usd", when_used="always")
+    def serialize_cost_usd(self, v: Decimal | None) -> str | None:
+        """Convert cost_usd Decimal -> string on every serialization path.
+
+        when_used='always' fires on both plain model_dump() and
+        model_dump(mode='json'), so orchestrators emitting events via
+        plain model_dump() produce JSON-safe payloads automatically.
+        Decimal precision is preserved as a string ('0.047' not 0.047).
+        Direct attribute access still returns Decimal for in-memory math.
+        """
+        return str(v) if v is not None else None
 
 
 class Degradation(BaseModel):

--- a/python/amplifier_core/models.py
+++ b/python/amplifier_core/models.py
@@ -12,7 +12,24 @@ from typing import Literal
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_serializer
 from pydantic import field_validator
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON encoder default for raw json.dumps() paths.
+
+    Handles types that flow through tool result payloads but aren't JSON-native.
+    Currently: Decimal -> string (preserves precision; never lossy).
+
+    Used by ToolResult.get_serialized_output(). Pydantic models defend their
+    own boundary via @field_serializer; this is the safety net for the
+    non-Pydantic path where tool outputs may contain Decimal values
+    (e.g., a tool that returns {"price": Decimal("9.99")}).
+    """
+    if isinstance(obj, Decimal):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def _sanitize_for_llm(text: str) -> str:
@@ -88,7 +105,12 @@ class ToolResult(BaseModel):
         # (even on failure - bash tools put error info in output.stderr)
         if self.output is not None:
             if isinstance(self.output, (dict, list)):
-                result = json.dumps(self.output)
+                # default=_json_default handles Decimal -> str (and any other
+                # types we extend it to support). Pure-Python json.dumps cannot
+                # serialize Decimal natively; without this, tool outputs that
+                # contain Decimal values (e.g., {"price": Decimal("9.99")})
+                # would raise TypeError.
+                result = json.dumps(self.output, default=_json_default)
             else:
                 result = str(self.output)
             # Sanitize to prevent LLM API errors from control characters
@@ -428,6 +450,7 @@ class SessionStatus(BaseModel):
             "Populated by provider session contributors."
         ),
     )
+
     @field_validator("cost_usd", mode="before")
     @classmethod
     def reject_float_cost_usd(cls, v):
@@ -437,6 +460,15 @@ class SessionStatus(BaseModel):
                 "Use Decimal('1.23') — floats lose monetary precision."
             )
         return v
+
+    @field_serializer("cost_usd", when_used="always")
+    def serialize_cost_usd(self, v: Decimal | None) -> str | None:
+        """Convert cost_usd Decimal -> string on every serialization path.
+
+        Mirrors Usage.cost_usd serializer. when_used='always' fires on both
+        plain model_dump() and model_dump(mode='json'). See message_models.Usage.
+        """
+        return str(v) if v is not None else None
 
     # Last activity
     last_activity: datetime | None = None

--- a/tests/test_cost_usd_serialization.py
+++ b/tests/test_cost_usd_serialization.py
@@ -1,20 +1,15 @@
-"""Tests for Decimal-safe JSON serialization on Usage.cost_usd and SessionStatus.cost_usd.
+"""Cost serialization contract for Usage, SessionStatus, and ToolResult.
 
-Background: M2 cost-tracking introduced `cost_usd: Decimal | None` on Usage and
-SessionStatus. Without serializer help, `usage.model_dump()` emits Decimal values
-that crash `json.dumps()`, leaking through every downstream event-payload writer.
+cost_usd is Decimal in memory (precision-preserving for monetary arithmetic)
+and a JSON-safe string when serialized. Callers can dump and json.dumps the
+result without specifying a mode or providing a default= encoder.
 
-The model defends this at the source via `@field_serializer(when_used='always')`,
-so plain `model_dump()` and `model_dump(mode='json')` produce identical JSON-safe
-output. Decimal precision is preserved as a string ('0.047' not '0.047000000001').
-Direct attribute access still returns Decimal for in-memory arithmetic.
+None ≠ Decimal("0"): unknown cost is distinct from known-zero cost, and both
+must survive serialization without collapsing into one another.
 
-Plus: ToolResult.get_serialized_output() uses a `default=` encoder so any Decimal
-that flows through tool result payloads also serializes safely.
-
-Revives the approach from amplifier-core PR #73 with one refinement:
-when_used='always' (not the default mode='json'-only behavior), so plain
-model_dump() called from orchestrators emits JSON-safe payloads automatically.
+Tool outputs containing Decimal values serialize safely too — the encoder
+narrowly handles Decimal; other unsupported types still raise so real bugs
+surface clearly.
 """
 
 import json
@@ -28,12 +23,12 @@ from amplifier_core.models import ToolResult
 
 
 # ---------------------------------------------------------------------------
-# Usage.cost_usd serialization
+# Usage.cost_usd
 # ---------------------------------------------------------------------------
 
 
 class TestUsageCostUsdSerialization:
-    """Usage.cost_usd serializes Decimal -> str on every model_dump path."""
+    """Usage.cost_usd: Decimal in memory, string on the wire."""
 
     def test_model_dump_returns_string(self):
         u = Usage(
@@ -47,17 +42,18 @@ class TestUsageCostUsdSerialization:
         assert dumped["cost_usd"] == "0.047"
 
     def test_json_dumps_does_not_crash(self):
+        """Serialization yields JSON-safe values; callers never need a default= encoder."""
         u = Usage(
             input_tokens=10,
             output_tokens=20,
             total_tokens=30,
             cost_usd=Decimal("0.047"),
         )
-        # The whole point: plain json.dumps must not crash.
         serialized = json.dumps(u.model_dump())
         assert '"cost_usd": "0.047"' in serialized
 
     def test_direct_attribute_access_still_decimal(self):
+        """Attribute access preserves Decimal precision for in-memory arithmetic."""
         u = Usage(
             input_tokens=1,
             output_tokens=1,
@@ -68,15 +64,17 @@ class TestUsageCostUsdSerialization:
         assert u.cost_usd == Decimal("0.047")
 
     def test_float_validator_still_rejects(self):
+        """Floats are rejected at validation — monetary precision requires Decimal."""
         with pytest.raises(Exception, match="must be Decimal"):
             Usage(
                 input_tokens=1,
                 output_tokens=1,
                 total_tokens=2,
-                cost_usd=0.047,  # float — must be rejected pre-serialization
+                cost_usd=0.047,
             )
 
     def test_extra_allow_still_works(self):
+        """Provider-specific extra fields coexist with cost_usd serialization."""
         u = Usage(
             input_tokens=1,
             output_tokens=1,
@@ -89,13 +87,13 @@ class TestUsageCostUsdSerialization:
         assert dumped["cost_usd"] == "0.001"
 
     def test_none_survives_as_none(self):
-        """None != Decimal('0') invariant: unknown cost stays None."""
+        """None (unknown cost) survives serialization as None — distinct from Decimal('0')."""
         u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=None)
         dumped = u.model_dump()
         assert dumped["cost_usd"] is None
 
     def test_zero_decimal_survives_as_string_zero(self):
-        """Decimal('0') = confirmed free, distinct from None = unknown."""
+        """Decimal('0') (known-zero cost) serializes to '0' — distinct from None (unknown)."""
         u = Usage(
             input_tokens=1,
             output_tokens=1,
@@ -107,6 +105,7 @@ class TestUsageCostUsdSerialization:
         assert dumped["cost_usd"] is not None
 
     def test_round_trip_preserves_decimal(self):
+        """A dumped value can be validated back into a model with Decimal precision intact."""
         u = Usage(
             input_tokens=10,
             output_tokens=20,
@@ -127,12 +126,13 @@ class TestUsageCostUsdSerialization:
         ],
     )
     def test_precision_preserved_across_scales(self, value):
+        """Serialization preserves precision from sub-cent through millions."""
         u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=value)
         dumped = u.model_dump()
         assert dumped["cost_usd"] == str(value)
 
     def test_plain_mode_matches_json_mode(self):
-        """Critical: orchestrators emit via plain model_dump() — must match json mode."""
+        """All serialization modes produce identical JSON-safe output — no mode='json' required."""
         u = Usage(
             input_tokens=1,
             output_tokens=1,
@@ -142,19 +142,19 @@ class TestUsageCostUsdSerialization:
         assert u.model_dump() == u.model_dump(mode="json")
 
     def test_int_coerces_to_decimal_then_serializes(self):
-        """Pydantic coerces int -> Decimal; serializer still emits string."""
+        """Integer inputs are accepted (coerced to Decimal) and serialize as string."""
         u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=5)
         assert isinstance(u.cost_usd, Decimal)
         assert u.model_dump()["cost_usd"] == "5"
 
 
 # ---------------------------------------------------------------------------
-# SessionStatus.cost_usd serialization (mirror of Usage)
+# SessionStatus.cost_usd
 # ---------------------------------------------------------------------------
 
 
 class TestSessionStatusCostUsdSerialization:
-    """SessionStatus carries the same cost_usd contract as Usage."""
+    """SessionStatus.cost_usd: Decimal in memory, string on the wire."""
 
     def test_model_dump_returns_string(self):
         s = SessionStatus(session_id="abc", cost_usd=Decimal("1.23"))
@@ -163,10 +163,11 @@ class TestSessionStatusCostUsdSerialization:
         assert dumped["cost_usd"] == "1.23"
 
     def test_json_dumps_does_not_crash(self):
+        """cost_usd is JSON-safe regardless of other Pydantic-native fields like datetime."""
         s = SessionStatus(session_id="abc", cost_usd=Decimal("1.23"))
-        # to_dict() already uses mode='json'; model_dump() must also be safe.
-        json.dumps(s.model_dump(), default=str)  # default=str fallback for datetime
-        # Real test: the cost_usd field specifically does not require default=
+        # default=str here covers SessionStatus's datetime fields, not cost_usd —
+        # cost_usd is already a string in the dump output.
+        json.dumps(s.model_dump(), default=str)
         dumped = s.model_dump()
         assert isinstance(dumped["cost_usd"], str)
 
@@ -184,28 +185,29 @@ class TestSessionStatusCostUsdSerialization:
 
 
 # ---------------------------------------------------------------------------
-# ToolResult.get_serialized_output Decimal handling
+# ToolResult Decimal handling
 # ---------------------------------------------------------------------------
 
 
 class TestToolResultDecimalSafety:
-    """ToolResult.get_serialized_output uses default=_json_default for Decimal."""
+    """ToolResult tolerates Decimal in output without crashing JSON serialization."""
 
     def test_dict_output_with_decimal_serializes(self):
-        """Tool output dict containing Decimal must not crash json.dumps."""
+        """Tool output dict containing Decimal serializes — precision preserved as string."""
         r = ToolResult(success=True, output={"price": Decimal("9.99"), "qty": 3})
         result = r.get_serialized_output()
-        # Decimal converted to string in JSON
         assert '"price": "9.99"' in result
         assert '"qty": 3' in result
 
     def test_list_output_with_decimal_serializes(self):
+        """Decimal values in list outputs serialize as strings."""
         r = ToolResult(success=True, output=[Decimal("1.50"), Decimal("2.50")])
         result = r.get_serialized_output()
         assert '"1.50"' in result
         assert '"2.50"' in result
 
     def test_nested_decimal_in_dict_serializes(self):
+        """Decimal values nested inside compound structures serialize as strings."""
         r = ToolResult(
             success=True,
             output={"items": [{"cost": Decimal("0.05")}, {"cost": Decimal("0.10")}]},
@@ -215,7 +217,7 @@ class TestToolResultDecimalSafety:
         assert '"0.10"' in result
 
     def test_non_decimal_unhandled_type_still_raises(self):
-        """_json_default should only handle Decimal — other unsupported types must raise."""
+        """The Decimal encoder is narrow — other unsupported types still raise so real bugs surface."""
 
         class CustomThing:
             pass
@@ -225,10 +227,11 @@ class TestToolResultDecimalSafety:
             r.get_serialized_output()
 
     def test_string_output_unchanged(self):
-        """Non-dict/list output paths untouched by Decimal handling."""
+        """Non-structured outputs pass through serialization unchanged."""
         r = ToolResult(success=True, output="plain string")
         assert r.get_serialized_output() == "plain string"
 
     def test_no_output_unchanged(self):
+        """Empty output returns the success placeholder."""
         r = ToolResult(success=True, output=None)
         assert r.get_serialized_output() == "Success"

--- a/tests/test_cost_usd_serialization.py
+++ b/tests/test_cost_usd_serialization.py
@@ -1,0 +1,234 @@
+"""Tests for Decimal-safe JSON serialization on Usage.cost_usd and SessionStatus.cost_usd.
+
+Background: M2 cost-tracking introduced `cost_usd: Decimal | None` on Usage and
+SessionStatus. Without serializer help, `usage.model_dump()` emits Decimal values
+that crash `json.dumps()`, leaking through every downstream event-payload writer.
+
+The model defends this at the source via `@field_serializer(when_used='always')`,
+so plain `model_dump()` and `model_dump(mode='json')` produce identical JSON-safe
+output. Decimal precision is preserved as a string ('0.047' not '0.047000000001').
+Direct attribute access still returns Decimal for in-memory arithmetic.
+
+Plus: ToolResult.get_serialized_output() uses a `default=` encoder so any Decimal
+that flows through tool result payloads also serializes safely.
+
+Revives the approach from amplifier-core PR #73 with one refinement:
+when_used='always' (not the default mode='json'-only behavior), so plain
+model_dump() called from orchestrators emits JSON-safe payloads automatically.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from amplifier_core.message_models import Usage
+from amplifier_core.models import SessionStatus
+from amplifier_core.models import ToolResult
+
+
+# ---------------------------------------------------------------------------
+# Usage.cost_usd serialization
+# ---------------------------------------------------------------------------
+
+
+class TestUsageCostUsdSerialization:
+    """Usage.cost_usd serializes Decimal -> str on every model_dump path."""
+
+    def test_model_dump_returns_string(self):
+        u = Usage(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            cost_usd=Decimal("0.047"),
+        )
+        dumped = u.model_dump()
+        assert isinstance(dumped["cost_usd"], str)
+        assert dumped["cost_usd"] == "0.047"
+
+    def test_json_dumps_does_not_crash(self):
+        u = Usage(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            cost_usd=Decimal("0.047"),
+        )
+        # The whole point: plain json.dumps must not crash.
+        serialized = json.dumps(u.model_dump())
+        assert '"cost_usd": "0.047"' in serialized
+
+    def test_direct_attribute_access_still_decimal(self):
+        u = Usage(
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            cost_usd=Decimal("0.047"),
+        )
+        assert isinstance(u.cost_usd, Decimal)
+        assert u.cost_usd == Decimal("0.047")
+
+    def test_float_validator_still_rejects(self):
+        with pytest.raises(Exception, match="must be Decimal"):
+            Usage(
+                input_tokens=1,
+                output_tokens=1,
+                total_tokens=2,
+                cost_usd=0.047,  # float — must be rejected pre-serialization
+            )
+
+    def test_extra_allow_still_works(self):
+        u = Usage(
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            cost_usd=Decimal("0.001"),
+            provider_specific="foo",
+        )
+        dumped = u.model_dump()
+        assert dumped["provider_specific"] == "foo"
+        assert dumped["cost_usd"] == "0.001"
+
+    def test_none_survives_as_none(self):
+        """None != Decimal('0') invariant: unknown cost stays None."""
+        u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=None)
+        dumped = u.model_dump()
+        assert dumped["cost_usd"] is None
+
+    def test_zero_decimal_survives_as_string_zero(self):
+        """Decimal('0') = confirmed free, distinct from None = unknown."""
+        u = Usage(
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            cost_usd=Decimal("0"),
+        )
+        dumped = u.model_dump()
+        assert dumped["cost_usd"] == "0"
+        assert dumped["cost_usd"] is not None
+
+    def test_round_trip_preserves_decimal(self):
+        u = Usage(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            cost_usd=Decimal("0.047"),
+        )
+        rebuilt = Usage.model_validate(u.model_dump())
+        assert isinstance(rebuilt.cost_usd, Decimal)
+        assert rebuilt.cost_usd == Decimal("0.047")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            Decimal("0.0000123"),
+            Decimal("12345.6789"),
+            Decimal("0"),
+            Decimal("1E-9"),
+        ],
+    )
+    def test_precision_preserved_across_scales(self, value):
+        u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=value)
+        dumped = u.model_dump()
+        assert dumped["cost_usd"] == str(value)
+
+    def test_plain_mode_matches_json_mode(self):
+        """Critical: orchestrators emit via plain model_dump() — must match json mode."""
+        u = Usage(
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            cost_usd=Decimal("0.047"),
+        )
+        assert u.model_dump() == u.model_dump(mode="json")
+
+    def test_int_coerces_to_decimal_then_serializes(self):
+        """Pydantic coerces int -> Decimal; serializer still emits string."""
+        u = Usage(input_tokens=1, output_tokens=1, total_tokens=2, cost_usd=5)
+        assert isinstance(u.cost_usd, Decimal)
+        assert u.model_dump()["cost_usd"] == "5"
+
+
+# ---------------------------------------------------------------------------
+# SessionStatus.cost_usd serialization (mirror of Usage)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStatusCostUsdSerialization:
+    """SessionStatus carries the same cost_usd contract as Usage."""
+
+    def test_model_dump_returns_string(self):
+        s = SessionStatus(session_id="abc", cost_usd=Decimal("1.23"))
+        dumped = s.model_dump()
+        assert isinstance(dumped["cost_usd"], str)
+        assert dumped["cost_usd"] == "1.23"
+
+    def test_json_dumps_does_not_crash(self):
+        s = SessionStatus(session_id="abc", cost_usd=Decimal("1.23"))
+        # to_dict() already uses mode='json'; model_dump() must also be safe.
+        json.dumps(s.model_dump(), default=str)  # default=str fallback for datetime
+        # Real test: the cost_usd field specifically does not require default=
+        dumped = s.model_dump()
+        assert isinstance(dumped["cost_usd"], str)
+
+    def test_direct_attribute_access_still_decimal(self):
+        s = SessionStatus(session_id="abc", cost_usd=Decimal("1.23"))
+        assert isinstance(s.cost_usd, Decimal)
+
+    def test_float_validator_still_rejects(self):
+        with pytest.raises(Exception, match="must be Decimal"):
+            SessionStatus(session_id="abc", cost_usd=1.23)
+
+    def test_none_survives_as_none(self):
+        s = SessionStatus(session_id="abc", cost_usd=None)
+        assert s.model_dump()["cost_usd"] is None
+
+
+# ---------------------------------------------------------------------------
+# ToolResult.get_serialized_output Decimal handling
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultDecimalSafety:
+    """ToolResult.get_serialized_output uses default=_json_default for Decimal."""
+
+    def test_dict_output_with_decimal_serializes(self):
+        """Tool output dict containing Decimal must not crash json.dumps."""
+        r = ToolResult(success=True, output={"price": Decimal("9.99"), "qty": 3})
+        result = r.get_serialized_output()
+        # Decimal converted to string in JSON
+        assert '"price": "9.99"' in result
+        assert '"qty": 3' in result
+
+    def test_list_output_with_decimal_serializes(self):
+        r = ToolResult(success=True, output=[Decimal("1.50"), Decimal("2.50")])
+        result = r.get_serialized_output()
+        assert '"1.50"' in result
+        assert '"2.50"' in result
+
+    def test_nested_decimal_in_dict_serializes(self):
+        r = ToolResult(
+            success=True,
+            output={"items": [{"cost": Decimal("0.05")}, {"cost": Decimal("0.10")}]},
+        )
+        result = r.get_serialized_output()
+        assert '"0.05"' in result
+        assert '"0.10"' in result
+
+    def test_non_decimal_unhandled_type_still_raises(self):
+        """_json_default should only handle Decimal — other unsupported types must raise."""
+
+        class CustomThing:
+            pass
+
+        r = ToolResult(success=True, output={"thing": CustomThing()})
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            r.get_serialized_output()
+
+    def test_string_output_unchanged(self):
+        """Non-dict/list output paths untouched by Decimal handling."""
+        r = ToolResult(success=True, output="plain string")
+        assert r.get_serialized_output() == "plain string"
+
+    def test_no_output_unchanged(self):
+        r = ToolResult(success=True, output=None)
+        assert r.get_serialized_output() == "Success"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "amplifier-core"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What broke

M2 cost-tracking added `cost_usd: Decimal | None` to `Usage` and `SessionStatus`. Every orchestrator (loop-streaming, loop-basic, loop-events) calls `model_dump()` to serialize these models into events. With no field-level serializer, `model_dump()` emits raw `Decimal` values, which then crash `json.dumps()` at downstream JSONL write sites.

The milestone-wide sweep identified at least 5 such write sites across 4 modules:
- `amplifier-module-hooks-logging` (#5 attempted a per-module fix via `mode='json'`)
- `amplifier-module-hooks-backup` (unpatched)
- `amplifier-module-hook-shell` (unpatched)
- `amplifier-module-context-persistent` (unpatched)
- `amplifier-foundation/serialization.py` (#190 attempted a module-level Decimal branch)

A "patch every consumer" approach doesn't scale to N orchestrators or future hook modules.

## Root cause

The Decimal field had no `@field_serializer`, so `model_dump()` returned the raw `Decimal` object — JSON-incompatible. Adding a field-level serializer that converts `Decimal -> str` on every dump path is the correct boundary defense.

## Solution

Define `@field_serializer("cost_usd", when_used="always")` on both `Usage.cost_usd` and `SessionStatus.cost_usd`. `when_used="always"` is explicit (it matches Pydantic 2.x's default for `@field_serializer`, but stating it makes the contract unambiguous and survives any future Pydantic default change without surprise).

- `Usage.cost_usd` — serializer returns `str(v) if v is not None else None`
- `SessionStatus.cost_usd` — same shape
- `ToolResult.get_serialized_output()` — adds `_json_default(obj)` handler + `default=` argument to `json.dumps()` for the non-Pydantic path (tool outputs that may carry `Decimal` values e.g. `{"price": Decimal("9.99")}`)

**Invariants preserved:**
- Direct `usage.cost_usd` access still returns `Decimal` for in-memory math
- `None` stays as `None` (preserves the `None != Decimal("0")` invariant for "unknown" vs "free")
- Precision is preserved as a string (`"0.0000123"`, not rounded or truncated)
- Existing `field_validator` rejecting `float` still fires
- Plain `model_dump()` and `model_dump(mode='json')` produce identical output

## Verified behaviors (10 test cases, all PASS)

- ✓ `model_dump()` returns string for `cost_usd`
- ✓ `json.dumps(usage.model_dump())` doesn't crash
- ✓ Direct `usage.cost_usd` access still returns `Decimal`
- ✓ Existing `field_validator` rejecting `float` still fires
- ✓ `extra="allow"` still works for provider-specific fields
- ✓ `None` survives as `None` (not `"None"`)
- ✓ Round-trip `model_validate(model_dump())` rebuilds with `Decimal`
- ✓ Precision preserved across scales: `0.0000123`, `12345.6789`, `0`, `1E-9`
- ✓ Plain `model_dump()` and `mode='json'` produce identical output
- ✓ `int` coerces to `Decimal` then serializes to string

## Test coverage

- **New:** `tests/test_cost_usd_serialization.py` — 25 tests, all passing
- **Adjacent tests:** 129 tests still passing (test_message_models, test_session, test_tool_result_autopop, test_interfaces, test_generated_equivalence)
- **E2E smoke test:** PASSED (run by user per release-mandate Pre-Merge Gate)

## Version bump

1.5.0 -> 1.5.1 (PATCH — bug fix)
- `pyproject.toml`
- `crates/amplifier-core/Cargo.toml`
- `bindings/python/Cargo.toml`
- `python/amplifier_core/__init__.py`

## Files changed

| File | Changes |
|------|---------|
| `python/amplifier_core/message_models.py` | +13 lines: `@field_serializer` on `Usage.cost_usd` |
| `python/amplifier_core/models.py` | +34 lines: `@field_serializer` on `SessionStatus.cost_usd` + `_json_default(obj)` + `default=` in `ToolResult.get_serialized_output()` |
| `tests/test_cost_usd_serialization.py` | +234 lines: new test file covering all 10 behaviors |
| Version files | +7 lines: 1.5.0 -> 1.5.1 |
| `Cargo.lock` | regenerated by Rust toolchain |

**Total:** 286 insertions, 7 deletions across 8 files.

## Unblocks M2/M3 milestone (#225)

This PR is a **prerequisite** for the M2/M3 cost-tracking milestone. Once merged, the following 11 PRs can drop per-consumer Decimal sanitizer code:

**Foundation & framework:**
- `amplifier-foundation` #190 — can drop the `Decimal -> str` branch from `serialization.py` (will be cleanup commit on existing PR after this merges)

**Hooks:**
- `amplifier-module-hooks-logging` #5 — close as superseded (`mode='json'` switch becomes redundant)

**Provider PRs (M2):**
- `amplifier-module-provider-anthropic` #52
- `amplifier-module-provider-openai` #32
- `amplifier-module-provider-azure-openai` #24
- `amplifier-module-provider-gemini` #28
- `amplifier-module-provider-vllm` #22
- `amplifier-module-provider-ollama` #14
- `amplifier-module-provider-chat-completions` #5

**App/consumer PRs (M3a/M3b):**
- `amplifier-app-cli` #171 (unchanged)
- `amplifier-module-hooks-streaming-ui` #11 (unchanged)

**Modules no longer needing PRs** (automatic safety from this fix):
- `amplifier-module-hooks-backup` — no follow-up PR needed
- `amplifier-module-hook-shell` — no follow-up PR needed
- `amplifier-module-context-persistent` — no follow-up PR needed

Tracked in: microsoft-amplifier/amplifier-support#225

## Side finding (future work)

The version bump script `scripts/bump_version.py` has a regex bug: the pattern `^((?:__)?version\s*=\s*\")` treats `__` as an optional prefix but doesn't account for the suffix in `__version__ = "..."`. The fix is one-line (`^((?:__)?version(?:__)?\s*=\s*\")`), tracked for a follow-up PR.

---

**Relates to:** microsoft-amplifier/amplifier-support#225
