### PR TITLE
fix(scripts): correct VERSION_LINE_RE regex to match __version__ suffix

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -33,7 +33,7 @@ VERSION_FILES = [
 ]
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
-VERSION_LINE_RE = re.compile(r'^((?:__)?version\s*=\s*")([^"]+)(")', re.MULTILINE)
+VERSION_LINE_RE = re.compile(r'^((?:__)?version(?:__)?\s*=\s*")([^"]+)(")', re.MULTILINE)
 
 
 def die(msg: str) -> NoReturn:


### PR DESCRIPTION
## Problem

`scripts/bump_version.py` used the pattern `(?:__)?version` which matched
`version` and `__version` but **not** `__version__` — the trailing `__` was
absent. This caused the script to silently fail to update
`python/amplifier_core/__init__.py` (which uses `__version__ = "..."`).

## Fix

One-line change to the compiled regex:

```python
# Before
VERSION_LINE_RE = re.compile(r'^((?:__)?version\s*=\s*")([^"]+)(")', re.MULTILINE)

# After
VERSION_LINE_RE = re.compile(r'^((?:__)?version(?:__)?\s*=\s*")([^"]+)(")', re.MULTILINE)
```

The pattern `(?:__)?version(?:__)?` now correctly handles all three forms:
`version`, `__version`, and `__version__`.

## Context

This was a tracked follow-up from the v1.5.1 release process. The tag `v1.5.1`
has already been pushed and PyPI publish is in progress; this PR lands the
script fix so future bumps work correctly.