### PR TITLE
fix: pass mode='json' to model_dump() in PyHookRegistry emit path

### DIFF
--- a/bindings/python/src/helpers.rs
+++ b/bindings/python/src/helpers.rs
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 /// Parse an approval system's decision string into a boolean.
 ///
@@ -33,14 +34,37 @@ pub(crate) fn wrap_future_as_coroutine<'py>(
     wrapper.call1((&future,))
 }
 
-/// Try `model_dump()` on a Python object (Pydantic BaseModel → dict).
-/// Falls back to the original object reference if not a Pydantic model.
+/// Try `model_dump(mode="json")` on a Python object (Pydantic BaseModel → JSON-safe dict).
+///
+/// Serialization strategy (three-tier):
+///
+/// 1. `model_dump(mode="json")` — preferred. Pydantic emits only JSON-native Python types
+///    (str, int, float, list, dict, bool, None). Fields like `cost_usd: Decimal` that have a
+///    `@field_serializer` convert correctly here. Any field type that Pydantic knows how to
+///    JSON-encode is handled without extra effort.
+///
+/// 2. `model_dump()` — fallback for objects whose `model_dump()` does not accept a `mode`
+///    kwarg (e.g. hand-rolled fakes, legacy Pydantic v1 models). The caller (`emit()`) then
+///    calls `json.dumps()` on the result; if any field is still non-JSON-native, that will
+///    surface as a `TypeError` rather than silently returning the raw object.
+///
+/// 3. Return the original object — if neither `model_dump` variant is callable. The caller
+///    attempts `json.dumps()` on the raw object; if it is not serializable, a `TypeError`
+///    propagates naturally.
 pub(crate) fn try_model_dump<'py>(obj: &Bound<'py, PyAny>) -> Bound<'py, PyAny> {
-    match obj.call_method0("model_dump") {
-        Ok(dict) => dict,
-        Err(e) => {
-            log::debug!("model_dump() failed (falling back to raw object): {e}");
-            obj.clone()
+    let py = obj.py();
+    // Tier 1: model_dump(mode="json") — JSON-safe output from real Pydantic models.
+    let kwargs = PyDict::new(py);
+    if kwargs.set_item("mode", "json").is_ok() {
+        if let Ok(dict) = obj.call_method("model_dump", (), Some(&kwargs)) {
+            return dict;
         }
     }
+    // Tier 2: bare model_dump() — for objects without a mode kwarg (fakes, Pydantic v1).
+    if let Ok(dict) = obj.call_method0("model_dump") {
+        return dict;
+    }
+    // Tier 3: raw object — let the caller's json.dumps() surface any TypeError.
+    log::debug!("model_dump() not available — passing raw object to json serialiser");
+    obj.clone()
 }


### PR DESCRIPTION
## Summary

- **Symptom:** Orchestrator crashes with `TypeError: Object of type Decimal is not JSON serializable` on the first LLM response, in `PyHookRegistry::emit()`. The crash fires before any Python hook handler gets control, making it impossible to intercept from the consumer side.
- **Root cause in the hook layer:** `try_model_dump()` in `helpers.rs` calls bare `model_dump()", which returns Python-native types including `Decimal` (used by `Usage.cost_usd`). The result is passed directly to `json.dumps()` with no custom encoder — which cannot handle `Decimal`.
- **Why the fix belongs here:** The hook emitter is the caller of `json.dumps()`. It is the correct place to request JSON-safe output. Putting `mode="json"` here means no consumer or model field ever needs to compensate for the hook system's serialization contract.

## What changed

**One function, `try_model_dump()` in `bindings/python/src/helpers.rs`:**

```rust
// Before
obj.call_method0("model_dump")

// After
let kwargs = PyDict::new(py);
kwargs.set_item("mode", "json")?;
obj.call_method("model_dump", (), Some(&kwargs))
```

`mode="json"` tells Pydantic to emit only JSON-native Python types (`str`, `int`, `float`, `list`, `dict`, `bool`, `None`) regardless of the field's underlying Python type or whether a `@field_serializer` is present on the model.

`try_model_dump()` is a shared helper called by both `emit()` and `emit_and_collect()` in `hooks.rs` — this one-function change covers the entire emit path.

## Why this is architecturally correct (not a workaround)

The immediate trigger is `amplifier-core 1.5.0` in the Docker worker image (`amplifier-cache:python`) predating the `@field_serializer` on `Usage.cost_usd` added in 1.5.1. But this fix is correct regardless of model version:

- The hook system should not depend on individual model fields having serializers to be JSON-safe.
- Any future field of any non-JSON-native type (e.g. `UUID`, `datetime`, custom type) in any hook payload would cause the same crash without this fix.
- This is defence-in-depth at the right layer: the serializer requests what it needs rather than relying on every upstream model to anticipate its requirements.

## Test plan

- [ ] Build `amplifier-cache:python` image after this merges and bump/release `amplifier-core`
- [ ] Run orchestrator resolver end-to-end — confirm no `TypeError: Object of type Decimal is not JSON serializable` on LLM response
- [ ] Verify `emit()` and `emit_and_collect()` both work correctly (both flow through `try_model_dump()`)
- [ ] Confirm fallback path (non-Pydantic objects) still passes the raw object through unchanged

Rebuilding `amplifier-cache:python` after this merges will fully resolve the crash for all consumers without any per-consumer workarounds.

Generated with [Amplifier](https://github.com/microsoft/amplifier)