### PR TITLE
ci: run Rust Core CI on push to main, not just PRs

### DIFF
--- a/.github/workflows/rust-core-ci.yml
+++ b/.github/workflows/rust-core-ci.yml
@@ -2,7 +2,7 @@ name: Rust Core CI
 
 on:
   push:
-    branches: [rust-core]
+    branches: [rust-core, main]
   pull_request:
     branches: [rust-core, main]
 


### PR DESCRIPTION
## Problem

The Rust Core CI workflow only triggers on pull requests and pushes to the `rust-core` branch. Pushes to `main` (merge commits, admin pushes, reverts, dependabot auto-merges) **do not run CI**.

This is how main went silently red after IT's wasmtime auto-fix in #74: the bump landed via dependabot auto-merge, no CI ran on the merge commit, and the breakage stayed hidden until the next PR (#79) opened and inherited the failed state.

## Fix

One line — add `main` to the push branches:

```yaml
on:
  push:
    branches: [rust-core, main]   # was: [rust-core]
  pull_request:
    branches: [rust-core, main]
```

## Effect

Future direct pushes to main run a full CI cycle on the new HEAD. Regressions are caught immediately, not at the next PR open.

## Note

This is a small `.github/workflows` change — no Rust or Python code touched. CI on the PR will run via the existing `pull_request` trigger before this change lands. After merge, the next push to main will exercise the new `push: main` trigger.