### PR TITLE
fix(session): emit session:start once per session, not per execute() — v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "amplifier-core"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "log",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "amplifier-core-py"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "amplifier-core",
  "log",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core-py"
-version = "1.5.3"
+version = "1.6.0"
 edition = "2021"
 description = "PyO3 bridge for amplifier-core Rust kernel"
 license = "MIT"

--- a/bindings/python/src/session.rs
+++ b/bindings/python/src/session.rs
@@ -393,16 +393,31 @@ impl PySession {
 
         // Clone references for the async block
         let coordinator = self.coordinator.clone_ref(py);
+        // Clone inner for the lifecycle-event guard (claim_lifecycle_event).
+        // The claim is checked inside the async block so it races correctly
+        // with any concurrent execute() calls.
+        let inner_for_lifecycle = Arc::clone(&self.inner);
 
         // Step 3: Return an awaitable that runs the full execute sequence
         wrap_future_as_coroutine(
             py,
             pyo3_async_runtimes::tokio::future_into_py(py, async move {
                 // 3a: Emit pre-execution event (session:start or session:resume)
-                // Call inner Rust emit directly — avoids the Future/coroutine mismatch that
-                // occurs when going through the Python PyO3 bridge (future_into_py returns
-                // a Future object, but into_future() expects a native coroutine).
-                hooks_inner.emit(event_base, pre_event_data).await;
+                // once per session lifetime — not once per execute() call.
+                // The core Session tracks the "already emitted" flag atomically;
+                // claim_lifecycle_event() returns true exactly once (the first
+                // execute() call), false on all subsequent calls.
+                let should_emit_lifecycle = {
+                    let session = inner_for_lifecycle.lock().await;
+                    session.claim_lifecycle_event()
+                };
+                if should_emit_lifecycle {
+                    // Call inner Rust emit directly — avoids the Future/coroutine
+                    // mismatch that occurs when going through the Python PyO3 bridge
+                    // (future_into_py returns a Future object, but into_future()
+                    // expects a native coroutine).
+                    hooks_inner.emit(event_base, pre_event_data).await;
+                }
 
                 // 3b: Emit debug events (delegates to Python for redact_secrets/truncate_values)
                 let debug_future = Python::try_attach(|py| {

--- a/bindings/python/tests/test_session_start_dedup.py
+++ b/bindings/python/tests/test_session_start_dedup.py
@@ -192,3 +192,130 @@ class TestSessionStartNotDuplicated:
             f"Non-raw session must emit session:start exactly once, "
             f"got {len(starts)}."
         )
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn regression tests — session:start must fire ONCE per session,
+# not once per execute() call (the Rust-port regression fixed in v1.6.0).
+#
+# Before the fix: every execute() call re-fired session:start, so 3 turns
+# yielded 3 events.  After the fix: exactly 1 event across any number of
+# execute() calls.
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStartOncePerSession:
+    """session:start must be emitted once per SESSION, not once per execute() call.
+
+    This tests the Rust-port regression (introduced 2026-02-14, d2826b4):
+    the Rust kernel placed session:start emission inside execute(), causing
+    every interactive turn to re-fire the event.  Hook handlers that
+    registered for session:start expecting once-per-session semantics
+    (e.g. hooks-routing, hook-context-intelligence) were re-running expensive
+    work on every turn, contributing 7-13s wall-clock cost per prompt.
+
+    Fix: session:start is guarded by an atomic flag so it fires at most once
+    per session lifetime regardless of how many times execute() is called.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_start_emitted_once_across_multiple_execute_calls(self):
+        """session:start must fire exactly once even when execute() is called 3 times."""
+        session = await _make_raw_session("multi-turn-test-1")
+
+        starts: list[dict] = []
+
+        async def _count_start(event: str, data: dict):
+            starts.append(data)
+            return None
+
+        session.coordinator.hooks.register(
+            "session:start", _count_start, name="test-multi-turn-counter"
+        )
+        _mount_stub_orchestrator(session)
+
+        await session.execute("turn one")
+        await session.execute("turn two")
+        await session.execute("turn three")
+
+        assert len(starts) == 1, (
+            f"session:start must fire exactly once per session regardless of "
+            f"how many execute() calls are made. Got {len(starts)} events "
+            f"across 3 execute() calls. "
+            f"This was the Rust-port regression: session:start was emitted "
+            f"inside execute() instead of once at session initialization."
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_resume_emitted_once_across_multiple_execute_calls(self):
+        """session:resume must fire exactly once for resumed sessions with multiple turns."""
+        config = {
+            "session": {
+                "orchestrator": "loop-basic",
+                "context": "context-simple",
+            },
+            "providers": [],
+            "hooks": [],
+            "tools": [],
+        }
+        session = RustSession(
+            config=config,
+            session_id="resumed-multi-turn",
+            is_resumed=True,
+        )
+        mock_init = AsyncMock()
+        with patch("amplifier_core._session_init.initialize_session", mock_init):
+            await session.initialize()
+
+        resumes: list[dict] = []
+
+        async def _count_resume(event: str, data: dict):
+            resumes.append(data)
+            return None
+
+        session.coordinator.hooks.register(
+            "session:resume", _count_resume, name="test-resume-counter"
+        )
+        _mount_stub_orchestrator(session)
+
+        await session.execute("turn one")
+        await session.execute("turn two")
+        await session.execute("turn three")
+
+        assert len(resumes) == 1, (
+            f"session:resume must fire exactly once per session regardless of "
+            f"how many execute() calls are made. Got {len(resumes)} events "
+            f"across 3 execute() calls."
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_start_not_emitted_on_second_or_third_turn(self):
+        """Verify session:start is absent on turns 2 and 3 — only present on turn 1."""
+        session = await _make_raw_session("multi-turn-test-2")
+
+        per_turn_counts: list[int] = []
+        cumulative: list[dict] = []
+
+        async def _count_start(event: str, data: dict):
+            cumulative.append(data)
+            return None
+
+        session.coordinator.hooks.register(
+            "session:start", _count_start, name="test-per-turn-counter"
+        )
+        _mount_stub_orchestrator(session)
+
+        await session.execute("turn one")
+        per_turn_counts.append(len(cumulative))  # After turn 1: should be 1
+
+        await session.execute("turn two")
+        per_turn_counts.append(len(cumulative))  # After turn 2: should still be 1
+
+        await session.execute("turn three")
+        per_turn_counts.append(len(cumulative))  # After turn 3: should still be 1
+
+        assert per_turn_counts == [1, 1, 1], (
+            f"session:start count after each turn should be [1, 1, 1]. "
+            f"Got {per_turn_counts}. "
+            f"Any count > 1 means session:start re-fired on a subsequent turn."
+        )

--- a/crates/amplifier-core/Cargo.toml
+++ b/crates/amplifier-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplifier-core"
-version = "1.5.3"
+version = "1.6.0"
 edition = "2021"
 description = "Pure Rust kernel for the Amplifier modular AI agent system"
 license = "MIT"

--- a/crates/amplifier-core/src/session.rs
+++ b/crates/amplifier-core/src/session.rs
@@ -141,6 +141,14 @@ pub struct Session {
     parent_id: Option<String>,
     coordinator: Arc<Coordinator>,
     initialized: AtomicBool,
+    /// Guards once-per-session emission of `session:start` / `session:resume`.
+    ///
+    /// The pre-Rust Python kernel emitted lifecycle events in `initialize()`,
+    /// not in `execute()`.  The Rust port incorrectly placed the emit inside
+    /// `execute()`, causing it to fire on every interactive turn.  This flag
+    /// ensures the emit fires at most once per session lifetime regardless of
+    /// how many times `execute()` is called.
+    lifecycle_event_emitted: AtomicBool,
     status: SessionState,
     is_resumed: bool,
 }
@@ -172,6 +180,7 @@ impl Session {
             parent_id,
             coordinator,
             initialized: AtomicBool::new(false),
+            lifecycle_event_emitted: AtomicBool::new(false),
             status: SessionState::Running,
             is_resumed: false,
         }
@@ -262,11 +271,25 @@ impl Session {
         self.initialized.store(false, Ordering::Relaxed);
     }
 
+    /// Claim the right to emit the session lifecycle event (`session:start` or
+    /// `session:resume`).
+    ///
+    /// Returns `true` exactly once per session lifetime — on the first call —
+    /// and `false` on all subsequent calls.  The caller that receives `true`
+    /// is responsible for emitting the event; all other callers must skip it.
+    ///
+    /// This restores the pre-Rust contract: lifecycle events fire once when the
+    /// session becomes ready, not on every `execute()` call.
+    pub fn claim_lifecycle_event(&self) -> bool {
+        // swap returns the OLD value; if old was false ⇒ first claim ⇒ return true
+        !self.lifecycle_event_emitted.swap(true, Ordering::AcqRel)
+    }
+
     /// Execute a prompt using the mounted orchestrator.
     ///
-    /// Auto-emits `session:start` (or `session:resume`) event, then delegates
-    /// to the orchestrator. Tracks status transitions on success, failure,
-    /// or cancellation.
+    /// Emits `session:start` (or `session:resume`) **once per session** on the
+    /// first `execute()` call, then delegates to the orchestrator on every
+    /// call.  Tracks status transitions on success, failure, or cancellation.
     ///
     /// # Errors
     ///
@@ -280,23 +303,27 @@ impl Session {
             return Err(AmplifierError::Session(SessionError::NotInitialized));
         }
 
-        // Emit lifecycle event
-        let event = if self.is_resumed {
-            events::SESSION_RESUME
-        } else {
-            events::SESSION_START
-        };
+        // Emit lifecycle event once per session (not once per execute() call).
+        // Pre-Rust Python kernel emitted in initialize(); we guard with an
+        // atomic flag so the event fires on the first execute() only.
+        if self.claim_lifecycle_event() {
+            let event = if self.is_resumed {
+                events::SESSION_RESUME
+            } else {
+                events::SESSION_START
+            };
 
-        self.coordinator
-            .hooks()
-            .emit(
-                event,
-                serde_json::json!({
-                    "session_id": self.session_id,
-                    "parent_id": self.parent_id,
-                }),
-            )
-            .await;
+            self.coordinator
+                .hooks()
+                .emit(
+                    event,
+                    serde_json::json!({
+                        "session_id": self.session_id,
+                        "parent_id": self.parent_id,
+                    }),
+                )
+                .await;
+        }
 
         // Get orchestrator
         let orchestrator = self.coordinator.orchestrator().ok_or_else(|| {
@@ -636,6 +663,8 @@ mod tests {
     // Hook events
     // ---------------------------------------------------------------
 
+    /// Verify session:start is emitted on first execute() — and only once
+    /// even when execute() is called multiple times on the same session.
     #[tokio::test]
     async fn execute_emits_session_start_event() {
         let config = SessionConfig::minimal("loop-basic", "context-simple");
@@ -660,16 +689,28 @@ mod tests {
         );
 
         session.set_initialized();
+        // Call execute() twice — event must appear exactly once (not twice)
         let _ = session.execute("hello").await;
+        let _ = session.execute("world").await;
 
         let events = handler.recorded_events();
-        assert!(
-            events.iter().any(|(name, _)| name == events::SESSION_START),
-            "Expected session:start event, got: {:?}",
+        let start_count = events
+            .iter()
+            .filter(|(name, _)| name == events::SESSION_START)
+            .count();
+        assert_eq!(
+            start_count,
+            1,
+            "session:start must be emitted exactly once per session. \
+             Got {} events across 2 execute() calls. \
+             Events: {:?}",
+            start_count,
             events.iter().map(|(n, _)| n).collect::<Vec<_>>()
         );
     }
 
+    /// Verify session:resume is emitted on first execute() for resumed sessions —
+    /// and only once even when execute() is called multiple times.
     #[tokio::test]
     async fn execute_emits_session_resume_for_resumed_session() {
         let config = SessionConfig::minimal("loop-basic", "context-simple");
@@ -693,15 +734,119 @@ mod tests {
         );
 
         session.set_initialized();
+        // Call execute() twice — event must appear exactly once (not twice)
         let _ = session.execute("hello").await;
+        let _ = session.execute("world").await;
 
         let events = handler.recorded_events();
-        assert!(
-            events
-                .iter()
-                .any(|(name, _)| name == events::SESSION_RESUME),
-            "Expected session:resume event, got: {:?}",
+        let resume_count = events
+            .iter()
+            .filter(|(name, _)| name == events::SESSION_RESUME)
+            .count();
+        assert_eq!(
+            resume_count,
+            1,
+            "session:resume must be emitted exactly once per session. \
+             Got {} events across 2 execute() calls. \
+             Events: {:?}",
+            resume_count,
             events.iter().map(|(n, _)| n).collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression test for the Rust-port regression: session:start must fire
+    /// exactly ONCE per session, not once per execute() call.
+    ///
+    /// Pre-Rust Python kernel: `execute()` had no `hooks.emit` calls at all.
+    /// Rust port (d2826b4, 2026-02-14): emit was placed inside `execute()`,
+    /// causing every interactive turn to re-fire the event.
+    ///
+    /// This test calls execute() three times and asserts exactly one
+    /// session:start event is captured.  It must FAIL before the fix and
+    /// PASS after.
+    #[tokio::test]
+    async fn session_start_emitted_once_across_multiple_execute_calls() {
+        let config = SessionConfig::minimal("loop-basic", "context-simple");
+        let mut session = Session::new(config, None, None);
+        session
+            .coordinator_mut()
+            .set_orchestrator(Arc::new(FakeOrchestrator::new("ok")));
+        session
+            .coordinator_mut()
+            .set_context(Arc::new(FakeContextManager::new()));
+        session
+            .coordinator_mut()
+            .mount_provider("test", Arc::new(FakeProvider::new("test", "hi")));
+
+        let handler = Arc::new(FakeHookHandler::new());
+        let _ = session.coordinator().hooks().register(
+            events::SESSION_START,
+            handler.clone(),
+            0,
+            Some("test-handler".into()),
+        );
+
+        session.set_initialized();
+        let _ = session.execute("turn one").await;
+        let _ = session.execute("turn two").await;
+        let _ = session.execute("turn three").await;
+
+        let events = handler.recorded_events();
+        let start_count = events
+            .iter()
+            .filter(|(name, _)| name == events::SESSION_START)
+            .count();
+        assert_eq!(
+            start_count,
+            1,
+            "session:start must fire exactly once per session, not per execute() call. \
+             Got {} events across 3 execute() calls. \
+             This is the Rust-port regression: lifecycle events belong at session \
+             initialization, not inside execute().",
+            start_count
+        );
+    }
+
+    /// Regression test: session:resume must also fire exactly once per session,
+    /// not once per execute() call for resumed sessions.
+    #[tokio::test]
+    async fn session_resume_emitted_once_across_multiple_execute_calls() {
+        let config = SessionConfig::minimal("loop-basic", "context-simple");
+        let mut session = Session::new_resumed(config, "resumed-id".into(), None);
+        session
+            .coordinator_mut()
+            .set_orchestrator(Arc::new(FakeOrchestrator::new("ok")));
+        session
+            .coordinator_mut()
+            .set_context(Arc::new(FakeContextManager::new()));
+        session
+            .coordinator_mut()
+            .mount_provider("test", Arc::new(FakeProvider::new("test", "hi")));
+
+        let handler = Arc::new(FakeHookHandler::new());
+        let _ = session.coordinator().hooks().register(
+            events::SESSION_RESUME,
+            handler.clone(),
+            0,
+            Some("test-handler".into()),
+        );
+
+        session.set_initialized();
+        let _ = session.execute("turn one").await;
+        let _ = session.execute("turn two").await;
+        let _ = session.execute("turn three").await;
+
+        let events = handler.recorded_events();
+        let resume_count = events
+            .iter()
+            .filter(|(name, _)| name == events::SESSION_RESUME)
+            .count();
+        assert_eq!(
+            resume_count,
+            1,
+            "session:resume must fire exactly once per session, not per execute() call. \
+             Got {} events across 3 execute() calls.",
+            resume_count
         );
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-core"
-version = "1.5.3"
+version = "1.6.0"
 description = "Rust kernel with Python bindings for the Amplifier modular AI agent framework"
 license = "MIT"
 readme = "README.md"

--- a/python/amplifier_core/__init__.py
+++ b/python/amplifier_core/__init__.py
@@ -6,7 +6,7 @@ extension module. Submodule paths (e.g. `from amplifier_core.session import
 AmplifierSession`) still give the pure-Python implementations.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"
 
 # --- Rust-backed primary types (THE SWITCHOVER) ---
 # These four were previously imported from their Python submodules.

--- a/python/amplifier_core/session.py
+++ b/python/amplifier_core/session.py
@@ -73,6 +73,11 @@ class AmplifierSession:
         self.config = config
         self.status = SessionStatus(session_id=self.session_id)
         self._initialized = False
+        # Guard: emit session:start / session:resume once per session, not per
+        # execute() call.  Restores the pre-Rust Python kernel contract where
+        # execute() had no hooks.emit calls — lifecycle events belonged to
+        # initialization, not to the orchestrator-dispatch loop.
+        self._lifecycle_event_emitted = False
 
         # Create coordinator with infrastructure context and injected UX systems
         self.coordinator = ModuleCoordinator(
@@ -133,24 +138,31 @@ class AmplifierSession:
         if not self._initialized:
             await self.initialize()
 
-        from .events import SESSION_RESUME, SESSION_START
+        # Emit session lifecycle event once per session (not per execute() call).
+        # Restores the pre-Rust Python kernel contract: execute() had no
+        # hooks.emit calls; lifecycle events belong at initialization, not
+        # inside the orchestrator-dispatch loop.
+        if not self._lifecycle_event_emitted:
+            self._lifecycle_event_emitted = True
 
-        # Choose event type based on whether this is a new or resumed session
-        event_base = SESSION_RESUME if self._is_resumed else SESSION_START
+            from .events import SESSION_RESUME, SESSION_START
 
-        # Emit session lifecycle event from kernel (single source of truth)
-        session_config = self.config.get("session", {})
-        session_metadata = session_config.get("metadata", {})
-        raw = session_config.get("raw", False)
+            # Choose event type based on whether this is a new or resumed session
+            event_base = SESSION_RESUME if self._is_resumed else SESSION_START
 
-        payload: dict = {
-            "session_id": self.session_id,
-            "parent_id": self.parent_id,
-            **({"metadata": session_metadata} if session_metadata else {}),
-        }
-        if raw:
-            payload["raw"] = redact_secrets(self.config)
-        await self.coordinator.hooks.emit(event_base, payload)
+            # Emit session lifecycle event from kernel (single source of truth)
+            session_config = self.config.get("session", {})
+            session_metadata = session_config.get("metadata", {})
+            raw = session_config.get("raw", False)
+
+            payload: dict = {
+                "session_id": self.session_id,
+                "parent_id": self.parent_id,
+                **({"metadata": session_metadata} if session_metadata else {}),
+            }
+            if raw:
+                payload["raw"] = redact_secrets(self.config)
+            await self.coordinator.hooks.emit(event_base, payload)
 
         orchestrator = self.coordinator.get("orchestrator")
         if not orchestrator:


### PR DESCRIPTION
## Root Cause

Rust port on 2026-02-14 (commit `d2826b4`) added `session:start` emission inside `Session::execute()`. Every interactive prompt re-fired the event. Hook authors (`hooks-routing`, `hook-context-intelligence`, others) registered handlers expecting once-per-session semantics — those handlers were re-running expensive work (HTTP calls to `list_models`, provider enumeration, agent iteration) on every turn, contributing ~7–13s wall-clock cost per interactive prompt.

## Evidence

- Sessions 11622fa7 (v1.1.0), 913b256a (v1.5.3) both showed 3× `session:start` in 3-turn interactive sessions
- Pre-Rust Python `amplifier_core/session.py` from commit `f6d8ed6` (2025-10-08) had NO `hooks.emit` in `execute()` — confirming this was a regression introduced during the Rust port
- Commit `d2826b4` message explicitly stated lifecycle events would be in the kernel, but the port embedded them in `execute()` rather than `initialize()`, breaking the once-per-session invariant

## Fix

Added `lifecycle_event_emitted: AtomicBool` field on `Session`; new `claim_lifecycle_event()` method atomically returns `true` once per session lifetime. All three emission sites (Rust kernel `execute()`, PyO3 binding, pure-Python session) guarded by this claim.

## Tests

- 2 new Rust tests (`session_start_emitted_once_across_multiple_execute_calls`, `session_resume_emitted_once_across_multiple_execute_calls`)
- 2 existing Rust tests strengthened from "at least 1" to "exactly 1"
- 3 new Python tests in `test_session_start_dedup.py::TestSessionStartOncePerSession` (will turn green after build/install)
- Full Rust test suite: 469 tests pass, 0 failures

## Behavior Change

`session:start` and `session:resume` now fire exactly once per session lifetime, not per `execute()` call. This restores the pre-Rust contract. `session:end` continues to fire once at cleanup (unchanged). `execute()` becomes pure orchestrator delegation.

## Performance Impact

Removes ~7–13 seconds of per-turn wall-clock cost in interactive sessions where bundle includes routing-matrix or context-intelligence hooks.