### PR TITLE
fix(fmt): apply rustfmt to session.rs test assertions

### DIFF
--- a/crates/amplifier-core/src/session.rs
+++ b/crates/amplifier-core/src/session.rs
@@ -797,8 +797,7 @@ mod tests {
             .filter(|(name, _)| name == events::SESSION_START)
             .count();
         assert_eq!(
-            start_count,
-            1,
+            start_count, 1,
             "session:start must fire exactly once per session, not per execute() call. \
              Got {} events across 3 execute() calls. \
              This is the Rust-port regression: lifecycle events belong at session \
@@ -842,8 +841,7 @@ mod tests {
             .filter(|(name, _)| name == events::SESSION_RESUME)
             .count();
         assert_eq!(
-            resume_count,
-            1,
+            resume_count, 1,
             "session:resume must fire exactly once per session, not per execute() call. \
              Got {} events across 3 execute() calls.",
             resume_count


### PR DESCRIPTION
## Problem

`Rust Core CI` has been failing on `main` since PR #84 (`fix(session): emit session:start once per session`) merged with admin-override despite a failing `Rustfmt` step.

```
Diff in crates/amplifier-core/src/session.rs:797:
             .filter(|(name, _)| name == events::SESSION_START)
             .count();
         assert_eq!(
-            start_count,
-            1,
+            start_count, 1,
             "session:start must fire exactly once per session\u2026"

Diff in crates/amplifier-core/src/session.rs:842:
         assert_eq!(
-            resume_count,
-            1,
+            resume_count, 1,
```

## Fix

`cargo fmt -p amplifier-core` \u2014 two assertion macros collapse to canonical formatting. Tests behave identically; this is pure whitespace.

## Verification (all four CI commands run locally on the fixed branch)

| Step | Result |
|------|--------|
| `cargo fmt -p amplifier-core -p amplifier-core-py --check` | \u2705 |
| `cargo check -p amplifier-core -p amplifier-core-py` | \u2705 |
| `cargo test -p amplifier-core --no-run` | \u2705 |
| `cargo clippy -p amplifier-core -p amplifier-core-py -- -D warnings` | \u2705 |

## Notes

- This is the third PR in this session to hit the Rust Core CI workflow. Worth flagging: PR #84 should have run rustfmt locally before pushing. The earlier push-to-main CI fix (#82) is now active, so future merges will catch this on the merge commit \u2014 but the fault remains that --admin bypass let it through.