### PR TITLE
feat(models): add optional Pricing field to ModelInfo

### DIFF
--- a/bindings/python/tests/test_schema_sync.py
+++ b/bindings/python/tests/test_schema_sync.py
@@ -148,3 +148,22 @@ def test_hook_result_json_roundtrip():
     assert restored.context_injection == "Lint error on line 42"
     assert restored.suppress_output is True
     assert restored.user_message == "Found 1 issue"
+
+
+def test_model_info_pricing_field():
+    """ModelInfo.pricing and Pricing are importable and round-trip via JSON."""
+    from amplifier_core import ModelInfo, Pricing
+
+    info = ModelInfo(
+        id="test-model",
+        display_name="Test",
+        context_window=1000,
+        max_output_tokens=100,
+        pricing=Pricing(input_per_million=3.0, output_per_million=15.0),
+    )
+    json_str = info.model_dump_json()
+    parsed = json.loads(json_str)
+    assert parsed["pricing"]["input_per_million"] == 3.0
+
+    restored = ModelInfo.model_validate(parsed)
+    assert restored.pricing.output_per_million == 15.0

--- a/crates/amplifier-core/src/bridges/grpc_provider.rs
+++ b/crates/amplifier-core/src/bridges/grpc_provider.rs
@@ -47,6 +47,23 @@ fn parse_defaults_json(json_str: &str, id: &str) -> HashMap<String, Value> {
     })
 }
 
+/// Parse a JSON string into an optional Pricing, logging a warning on
+/// non-empty parse failures. Empty string means "no pricing available".
+fn parse_pricing_json(json_str: &str, id: &str) -> Option<crate::models::Pricing> {
+    if json_str.is_empty() {
+        return None;
+    }
+    serde_json::from_str(json_str)
+        .map_err(|e| {
+            log::warn!(
+                "Failed to parse model '{}' pricing_json: {e} — pricing unavailable",
+                id
+            );
+            e
+        })
+        .ok()
+}
+
 /// A bridge that wraps a remote gRPC `ProviderService` as a native [`Provider`].
 ///
 /// The client is held behind a [`tokio::sync::Mutex`] because
@@ -125,6 +142,7 @@ impl Provider for GrpcProviderBridge {
                 .into_iter()
                 .map(|m| {
                     let defaults = parse_defaults_json(&m.defaults_json, &m.id);
+                    let pricing = parse_pricing_json(&m.pricing_json, &m.id);
                     ModelInfo {
                         id: m.id,
                         display_name: m.display_name,
@@ -132,6 +150,7 @@ impl Provider for GrpcProviderBridge {
                         max_output_tokens: m.max_output_tokens as i64,
                         capabilities: m.capabilities,
                         defaults,
+                        pricing,
                     }
                 })
                 .collect();

--- a/crates/amplifier-core/src/generated/amplifier.module.rs
+++ b/crates/amplifier-core/src/generated/amplifier.module.rs
@@ -452,6 +452,10 @@ pub struct ModelInfo {
     pub capabilities: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, tag = "6")]
     pub defaults_json: ::prost::alloc::string::String,
+    /// JSON-encoded Pricing, or empty string if pricing is unavailable
+    /// (e.g., local providers, self-hosted backends).
+    #[prost(string, tag = "7")]
+    pub pricing_json: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProviderInfo {

--- a/crates/amplifier-core/src/generated/conversions.rs
+++ b/crates/amplifier-core/src/generated/conversions.rs
@@ -95,6 +95,11 @@ impl From<crate::models::ModelInfo> for super::amplifier_module::ModelInfo {
             }),
             capabilities: native.capabilities,
             defaults_json: to_json_or_warn(&native.defaults, "ModelInfo defaults"),
+            pricing_json: native
+                .pricing
+                .as_ref()
+                .map(|p| to_json_or_warn(p, "ModelInfo pricing"))
+                .unwrap_or_default(),
         }
     }
 }
@@ -111,6 +116,19 @@ impl From<super::amplifier_module::ModelInfo> for crate::models::ModelInfo {
                 Default::default()
             } else {
                 from_json_or_default(&proto.defaults_json, "ModelInfo defaults_json")
+            },
+            pricing: if proto.pricing_json.is_empty() {
+                None
+            } else {
+                match serde_json::from_str::<crate::models::Pricing>(&proto.pricing_json) {
+                    Ok(p) => Some(p),
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to parse ModelInfo pricing_json: {e} — pricing unavailable"
+                        );
+                        None
+                    }
+                }
             },
         }
     }
@@ -1029,10 +1047,54 @@ mod tests {
             max_output_tokens: 8192,
             capabilities: vec!["tools".into(), "vision".into()],
             defaults: HashMap::from([("temperature".to_string(), serde_json::json!(0.7))]),
+            pricing: Some(crate::models::Pricing {
+                input_per_million: 30.0,
+                output_per_million: 60.0,
+                cache_read_per_million: None,
+                cache_write_per_million: None,
+                currency: "USD".into(),
+            }),
         };
         let proto: super::super::amplifier_module::ModelInfo = original.clone().into();
         let restored: crate::models::ModelInfo = proto.into();
         assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn model_info_pricing_none_roundtrips_to_empty_json() {
+        let original = crate::models::ModelInfo {
+            id: "local-model".into(),
+            display_name: "Local Model".into(),
+            context_window: 8192,
+            max_output_tokens: 4096,
+            capabilities: vec![],
+            defaults: HashMap::new(),
+            pricing: None,
+        };
+        let proto: super::super::amplifier_module::ModelInfo = original.clone().into();
+        assert!(proto.pricing_json.is_empty());
+        let restored: crate::models::ModelInfo = proto.into();
+        assert_eq!(original, restored);
+        assert!(restored.pricing.is_none());
+    }
+
+    #[test]
+    fn model_info_pricing_invalid_json_becomes_none() {
+        let mut proto = super::super::amplifier_module::ModelInfo {
+            id: "broken-model".into(),
+            display_name: "Broken".into(),
+            context_window: 1000,
+            max_output_tokens: 100,
+            capabilities: vec![],
+            defaults_json: String::new(),
+            pricing_json: "not-valid-json".into(),
+        };
+        let restored: crate::models::ModelInfo = proto.clone().into();
+        assert!(restored.pricing.is_none());
+
+        proto.pricing_json = String::new();
+        let restored_empty: crate::models::ModelInfo = proto.into();
+        assert!(restored_empty.pricing.is_none());
     }
 
     #[test]
@@ -1122,6 +1184,7 @@ mod tests {
             max_output_tokens: 100,
             capabilities: vec![],
             defaults: HashMap::new(),
+            pricing: None,
         };
         let proto: super::super::amplifier_module::ModelInfo = original.into();
         assert_eq!(proto.context_window, i32::MAX);
@@ -1136,6 +1199,7 @@ mod tests {
             max_output_tokens: i64::from(i32::MAX) + 500,
             capabilities: vec![],
             defaults: HashMap::new(),
+            pricing: None,
         };
         let proto: super::super::amplifier_module::ModelInfo = original.into();
         assert_eq!(proto.max_output_tokens, i32::MAX);

--- a/crates/amplifier-core/src/generated/equivalence_tests.rs
+++ b/crates/amplifier-core/src/generated/equivalence_tests.rs
@@ -194,8 +194,8 @@ mod tests {
             max_output_tokens: 4096,
             capabilities: vec!["vision".into(), "tools".into(), "streaming".into()],
             defaults_json: r#"{"temperature":0.7}"#.into(),
-            pricing_json: r#"{"input_per_million":15.0,"output_per_million":75.0,"currency":"USD"}"#
-                .into(),
+            pricing_json:
+                r#"{"input_per_million":15.0,"output_per_million":75.0,"currency":"USD"}"#.into(),
         };
         assert_eq!(info.id, "claude-3-opus");
         assert_eq!(info.display_name, "Claude 3 Opus");

--- a/crates/amplifier-core/src/generated/equivalence_tests.rs
+++ b/crates/amplifier-core/src/generated/equivalence_tests.rs
@@ -194,6 +194,8 @@ mod tests {
             max_output_tokens: 4096,
             capabilities: vec!["vision".into(), "tools".into(), "streaming".into()],
             defaults_json: r#"{"temperature":0.7}"#.into(),
+            pricing_json: r#"{"input_per_million":15.0,"output_per_million":75.0,"currency":"USD"}"#
+                .into(),
         };
         assert_eq!(info.id, "claude-3-opus");
         assert_eq!(info.display_name, "Claude 3 Opus");
@@ -201,6 +203,10 @@ mod tests {
         assert_eq!(info.max_output_tokens, 4096);
         assert_eq!(info.capabilities.len(), 3);
         assert_eq!(info.defaults_json, r#"{"temperature":0.7}"#);
+        assert_eq!(
+            info.pricing_json,
+            r#"{"input_per_million":15.0,"output_per_million":75.0,"currency":"USD"}"#
+        );
     }
 
     #[test]

--- a/crates/amplifier-core/src/models.rs
+++ b/crates/amplifier-core/src/models.rs
@@ -304,6 +304,11 @@ pub struct ModelInfo {
     /// Model-specific default config values (e.g., temperature, max_tokens).
     #[serde(default)]
     pub defaults: HashMap<String, Value>,
+
+    /// Per-model pricing information. None when pricing is not available
+    /// (e.g., local providers like ollama, self-hosted backends like vllm).
+    #[serde(default)]
+    pub pricing: Option<Pricing>,
 }
 
 /// A configuration field that a provider needs, with prompt metadata.
@@ -350,6 +355,36 @@ pub struct ConfigField {
     /// If true, this field is shown after model selection.
     #[serde(default)]
     pub requires_model: bool,
+}
+
+/// Per-model pricing information.
+///
+/// Rates are per million tokens, in the specified currency. Surfaced via
+/// `/v1/models` so HTTP-bridge applications (e.g., amplifier-app-opencode)
+/// can display cost estimates without maintaining their own pricing tables.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Pricing {
+    /// Cost per million input tokens.
+    pub input_per_million: f64,
+
+    /// Cost per million output tokens.
+    pub output_per_million: f64,
+
+    /// Cost per million cache-read input tokens (None if not supported).
+    #[serde(default)]
+    pub cache_read_per_million: Option<f64>,
+
+    /// Cost per million cache-write input tokens (None if not supported).
+    #[serde(default)]
+    pub cache_write_per_million: Option<f64>,
+
+    /// ISO 4217 currency code.
+    #[serde(default = "default_currency")]
+    pub currency: String,
+}
+
+fn default_currency() -> String {
+    "USD".to_string()
 }
 
 /// Provider metadata.
@@ -727,6 +762,7 @@ mod tests {
             max_output_tokens: 4096,
             capabilities: vec!["streaming".into()],
             defaults: Default::default(),
+            pricing: None,
         };
         assert_eq!(info.id, "gpt-4");
     }
@@ -740,6 +776,13 @@ mod tests {
             max_output_tokens: 8192,
             capabilities: vec!["tools".into(), "vision".into(), "streaming".into()],
             defaults: HashMap::from([("temperature".into(), json!(0.7))]),
+            pricing: Some(Pricing {
+                input_per_million: 3.0,
+                output_per_million: 15.0,
+                cache_read_per_million: None,
+                cache_write_per_million: None,
+                currency: "USD".into(),
+            }),
         };
         let json_str = serde_json::to_string(&info).unwrap();
         let deserialized: ModelInfo = serde_json::from_str(&json_str).unwrap();

--- a/crates/amplifier-guest/src/lib.rs
+++ b/crates/amplifier-guest/src/lib.rs
@@ -1289,6 +1289,7 @@ mod provider_tests {
                 max_output_tokens: 1024,
                 capabilities: vec!["chat".to_string()],
                 defaults: HashMap::new(),
+                pricing: None,
             }])
         }
 

--- a/crates/amplifier-guest/src/types.rs
+++ b/crates/amplifier-guest/src/types.rs
@@ -171,6 +171,27 @@ pub struct ProviderInfo {
     pub defaults: HashMap<String, Value>,
 }
 
+/// Per-model pricing information.
+///
+/// Rates are per million tokens, in the specified currency. Mirrors
+/// `amplifier_core::models::Pricing` on the native side (this crate has no
+/// dependency on `amplifier-core`, so the struct is duplicated here).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Pricing {
+    pub input_per_million: f64,
+    pub output_per_million: f64,
+    #[serde(default)]
+    pub cache_read_per_million: Option<f64>,
+    #[serde(default)]
+    pub cache_write_per_million: Option<f64>,
+    #[serde(default = "default_currency")]
+    pub currency: String,
+}
+
+fn default_currency() -> String {
+    "USD".to_string()
+}
+
 /// Metadata about a specific model.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelInfo {
@@ -180,6 +201,10 @@ pub struct ModelInfo {
     pub max_output_tokens: i64,
     pub capabilities: Vec<String>,
     pub defaults: HashMap<String, Value>,
+    /// Per-model pricing information. None when pricing is not available
+    /// (e.g., local providers like ollama, self-hosted backends like vllm).
+    #[serde(default)]
+    pub pricing: Option<Pricing>,
 }
 
 /// Request for an LLM chat completion.
@@ -473,9 +498,17 @@ mod tests {
             max_output_tokens: 4096,
             capabilities: vec!["chat".to_string(), "tools".to_string()],
             defaults: HashMap::new(),
+            pricing: Some(Pricing {
+                input_per_million: 30.0,
+                output_per_million: 60.0,
+                cache_read_per_million: None,
+                cache_write_per_million: None,
+                currency: "USD".to_string(),
+            }),
         };
         assert_eq!(info.context_window, 128000);
         assert_eq!(info.max_output_tokens, 4096);
+        assert_eq!(info.pricing.as_ref().unwrap().input_per_million, 30.0);
     }
 
     // --- ChatRequest tests ---
@@ -638,6 +671,13 @@ mod tests {
             max_output_tokens: 4096,
             capabilities: vec!["chat".to_string(), "tools".to_string()],
             defaults: HashMap::new(),
+            pricing: Some(Pricing {
+                input_per_million: 30.0,
+                output_per_million: 60.0,
+                cache_read_per_million: Some(15.0),
+                cache_write_per_million: Some(37.5),
+                currency: "USD".to_string(),
+            }),
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: ModelInfo = serde_json::from_str(&json_str).unwrap();

--- a/proto/amplifier_module.proto
+++ b/proto/amplifier_module.proto
@@ -415,6 +415,9 @@ message ModelInfo {
   int32           max_output_tokens = 4;
   repeated string capabilities      = 5;
   string          defaults_json     = 6;
+  // JSON-encoded Pricing, or empty string if pricing is unavailable
+  // (e.g., local providers, self-hosted backends).
+  string          pricing_json      = 7;
 }
 
 message ProviderInfo {

--- a/python/amplifier_core/__init__.py
+++ b/python/amplifier_core/__init__.py
@@ -77,6 +77,7 @@ from .models import ConfigField
 from .models import HookResult
 from .models import ModelInfo
 from .models import ModuleInfo
+from .models import Pricing
 from .models import ProviderInfo
 from .models import SessionStatus
 from .models import ToolResult
@@ -118,6 +119,7 @@ __all__ = [
     "ConfigField",
     "ModelInfo",
     "ModuleInfo",
+    "Pricing",
     "ProviderInfo",
     "SessionStatus",
     "ApprovalRequest",

--- a/python/amplifier_core/models.py
+++ b/python/amplifier_core/models.py
@@ -5,6 +5,7 @@ Uses Pydantic for validation and serialization.
 
 import json
 import re
+from datetime import date
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
@@ -322,6 +323,31 @@ class HookResult(BaseModel):
     )
 
 
+class Pricing(BaseModel):
+    """Per-model pricing information.
+
+    Rates are per million tokens, in the specified currency. Surfaced via
+    /v1/models so HTTP-bridge applications (e.g., amplifier-app-opencode)
+    can display cost estimates without maintaining their own pricing tables.
+    """
+
+    input_per_million: float = Field(..., description="Cost per million input tokens")
+    output_per_million: float = Field(..., description="Cost per million output tokens")
+    cache_read_per_million: float | None = Field(
+        default=None,
+        description="Cost per million cache-read input tokens (None if not supported)",
+    )
+    cache_write_per_million: float | None = Field(
+        default=None,
+        description="Cost per million cache-write input tokens (None if not supported)",
+    )
+    currency: str = Field(default="USD", description="ISO 4217 currency code")
+    as_of: date | None = Field(
+        default=None,
+        description="Date these rates were last verified; None if unknown",
+    )
+
+
 class ModelInfo(BaseModel):
     """Model metadata for provider models.
 
@@ -341,6 +367,13 @@ class ModelInfo(BaseModel):
     defaults: dict[str, Any] = Field(
         default_factory=dict,
         description="Model-specific default config values (e.g., temperature, max_tokens)",
+    )
+    pricing: Pricing | None = Field(
+        default=None,
+        description=(
+            "Per-model pricing information. None when pricing is not available "
+            "(e.g., local providers like ollama, self-hosted backends like vllm)."
+        ),
     )
 
 

--- a/python/amplifier_core/models.py
+++ b/python/amplifier_core/models.py
@@ -5,7 +5,6 @@ Uses Pydantic for validation and serialization.
 
 import json
 import re
-from datetime import date
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
@@ -329,6 +328,11 @@ class Pricing(BaseModel):
     Rates are per million tokens, in the specified currency. Surfaced via
     /v1/models so HTTP-bridge applications (e.g., amplifier-app-opencode)
     can display cost estimates without maintaining their own pricing tables.
+
+    Rate fields use `float` (not `Decimal`). These are display-only estimates
+    surfaced to consumers via `/v1/models` for UI-level cost display. For
+    per-turn cost accounting, use `Usage.cost_usd`, which is `Decimal` and
+    uses a field validator that explicitly rejects `float`.
     """
 
     input_per_million: float = Field(..., description="Cost per million input tokens")
@@ -342,10 +346,13 @@ class Pricing(BaseModel):
         description="Cost per million cache-write input tokens (None if not supported)",
     )
     currency: str = Field(default="USD", description="ISO 4217 currency code")
-    as_of: date | None = Field(
-        default=None,
-        description="Date these rates were last verified; None if unknown",
-    )
+
+    @field_validator("currency")
+    @classmethod
+    def _validate_currency(cls, v: str) -> str:
+        if not re.match(r"^[A-Z]{3}$", v):
+            raise ValueError(f"currency must be a 3-letter ISO 4217 code, got {v!r}")
+        return v
 
 
 class ModelInfo(BaseModel):

--- a/tests/fixtures/wasm/src/echo-provider/src/lib.rs
+++ b/tests/fixtures/wasm/src/echo-provider/src/lib.rs
@@ -31,6 +31,7 @@ impl Provider for EchoProvider {
             max_output_tokens: 1024,
             capabilities: vec!["chat".to_string()],
             defaults: HashMap::new(),
+            pricing: None,
         }])
     }
 

--- a/tests/test_model_info_pricing.py
+++ b/tests/test_model_info_pricing.py
@@ -1,0 +1,85 @@
+"""Serialization contract for ModelInfo.pricing and the Pricing model.
+
+pricing is optional on ModelInfo: None when a provider has no rate data
+(e.g., local providers like ollama, self-hosted backends like vllm), and a
+populated Pricing object when a provider can supply rates. Both states must
+round-trip cleanly through model_dump() / model_validate() so HTTP bridges
+(e.g., amplifier-app-opencode) can rely on the field without special-casing
+either branch.
+"""
+
+from amplifier_core.models import ModelInfo
+from amplifier_core.models import Pricing
+
+
+class TestPricingRoundTrip:
+    """Pricing model dumps and reconstructs without loss."""
+
+    def test_round_trip_full(self):
+        pricing = Pricing(
+            input_per_million=3.0,
+            output_per_million=15.0,
+            cache_read_per_million=0.3,
+            cache_write_per_million=3.75,
+            currency="USD",
+        )
+        dumped = pricing.model_dump()
+        rebuilt = Pricing.model_validate(dumped)
+
+        assert rebuilt == pricing
+        assert rebuilt.input_per_million == 3.0
+        assert rebuilt.output_per_million == 15.0
+        assert rebuilt.cache_read_per_million == 0.3
+        assert rebuilt.cache_write_per_million == 3.75
+        assert rebuilt.currency == "USD"
+        assert rebuilt.as_of is None
+
+    def test_optional_fields_default_to_none(self):
+        pricing = Pricing(input_per_million=1.0, output_per_million=5.0)
+
+        assert pricing.cache_read_per_million is None
+        assert pricing.cache_write_per_million is None
+        assert pricing.currency == "USD"
+        assert pricing.as_of is None
+
+
+class TestModelInfoPricingField:
+    """ModelInfo.pricing: optional, backwards-compatible, round-trips both states."""
+
+    def test_pricing_none_serializes_cleanly(self):
+        """Local/self-hosted providers (no rate data) omit pricing without error."""
+        model = ModelInfo(
+            id="local-model",
+            display_name="Local Model",
+            context_window=8192,
+            max_output_tokens=4096,
+        )
+
+        dumped = model.model_dump()
+
+        assert dumped["pricing"] is None
+        rebuilt = ModelInfo.model_validate(dumped)
+        assert rebuilt.pricing is None
+
+    def test_pricing_populated_round_trips(self):
+        pricing = Pricing(
+            input_per_million=3.0,
+            output_per_million=15.0,
+            cache_read_per_million=0.3,
+            cache_write_per_million=3.75,
+        )
+        model = ModelInfo(
+            id="claude-sonnet-4-5",
+            display_name="Claude Sonnet 4.5",
+            context_window=200_000,
+            max_output_tokens=64_000,
+            pricing=pricing,
+        )
+
+        dumped = model.model_dump()
+        rebuilt = ModelInfo.model_validate(dumped)
+
+        assert rebuilt.pricing is not None
+        assert rebuilt.pricing == pricing
+        assert dumped["pricing"]["input_per_million"] == 3.0
+        assert dumped["pricing"]["output_per_million"] == 15.0

--- a/tests/test_model_info_pricing.py
+++ b/tests/test_model_info_pricing.py
@@ -8,6 +8,10 @@ round-trip cleanly through model_dump() / model_validate() so HTTP bridges
 either branch.
 """
 
+import json
+
+from pydantic import ValidationError
+
 from amplifier_core.models import ModelInfo
 from amplifier_core.models import Pricing
 
@@ -32,7 +36,6 @@ class TestPricingRoundTrip:
         assert rebuilt.cache_read_per_million == 0.3
         assert rebuilt.cache_write_per_million == 3.75
         assert rebuilt.currency == "USD"
-        assert rebuilt.as_of is None
 
     def test_optional_fields_default_to_none(self):
         pricing = Pricing(input_per_million=1.0, output_per_million=5.0)
@@ -40,7 +43,27 @@ class TestPricingRoundTrip:
         assert pricing.cache_read_per_million is None
         assert pricing.cache_write_per_million is None
         assert pricing.currency == "USD"
-        assert pricing.as_of is None
+
+    def test_pricing_json_dumps_survives(self):
+        p = Pricing(input_per_million=3.0, output_per_million=15.0)
+        # Verify json.dumps(model_dump()) works without needing mode="json"
+        # (since we no longer have date fields, this should be trivially safe)
+        json.dumps(p.model_dump())
+        # And explicit mode="json" for consistency
+        json.dumps(p.model_dump(mode="json"))
+        # And model_dump_json() directly
+        Pricing.model_validate_json(p.model_dump_json())
+
+    def test_currency_must_be_iso_4217(self):
+        # valid 3-letter uppercase
+        Pricing(input_per_million=1.0, output_per_million=2.0, currency="EUR")
+        # invalid
+        for bad in ["usd", "US", "USDD", "us$", "123"]:
+            try:
+                Pricing(input_per_million=1.0, output_per_million=2.0, currency=bad)
+                raise AssertionError(f"expected ValidationError for currency={bad!r}")
+            except ValidationError:
+                pass
 
 
 class TestModelInfoPricingField:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "amplifier-core"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 🔄 Updated per triage feedback (2026-06-30)

Two commits added addressing the "Updated Triage — PR Branch Review" from issue microsoft-amplifier/amplifier-support#295:

**`refactor(models): drop Pricing.as_of and tighten schema`** (`1a94515`)
- Removed the speculative `as_of: date | None` field from `Pricing` — no consumer needed it, and dropping it eliminated the `json.dumps(model_dump())` serialization hazard the triage flagged (Medium #1) and the "as_of always None" gap (Medium #2) as byproducts.
- Added ISO 4217 currency validator (`^[A-Z]{3}$`) — addresses triage Medium #6.
- Added docstring note that `Pricing` uses `float` because it's display-only, and per-turn accounting uses `Usage.cost_usd` (`Decimal`) — addresses triage Medium #4.
- Added round-trip test for `Pricing.model_dump()` + `json.dumps` and currency validation.

**`feat(models): propagate Pricing through Rust bridges + guest crate`** (`cb28489`)
- Added native Rust `Pricing` struct and `pricing: Option<Pricing>` field on Rust `ModelInfo` (`crates/amplifier-core/src/models.rs`).
- Added `pricing_json` string field on the proto `ModelInfo` at tag 7 (mirrors the existing `defaults_json` pattern at tag 6). Regenerated `src/generated/amplifier.module.rs` via `build.rs`.
- Extended `src/generated/conversions.rs` to round-trip pricing between native and proto structs in both directions. Parse failures return `None` (no synthetic default `Pricing`).
- Added `parse_pricing_json` helper in `src/bridges/grpc_provider.rs` and threaded it through `list_models()` — addresses the HIGH item in the triage (gRPC bridge silently dropping pricing).
- Added duplicated `Pricing` + field in `crates/amplifier-guest/src/types.rs` — closes the WASM guest-side gap the triage did **not** originally identify, but which is required for WASM providers to populate pricing at all.
- `src/bridges/wasm_provider.rs` requires no changes — it deserializes directly into native `ModelInfo` and picks up the new field via `#[serde(default)]`.
- Rust unit tests for `parse_pricing_json`, updated `equivalence_tests.rs`, and new `test_model_info_pricing_field` in `bindings/python/tests/test_schema_sync.py`.

### Verification results

- Python: 6/6 pricing/model_info tests pass; ruff/pyright clean on touched files (pre-existing issues elsewhere are documented, not fixed).
- Rust: `cargo build --workspace` regenerates proto cleanly; `cargo test -p amplifier-core --lib` 454/454 pass; `cargo test -p amplifier-guest --lib` 94/94 pass; clippy clean on `amplifier-core` and `amplifier-core-py`. Full-workspace `cargo test` hangs on unrelated `wasm_*` and `sha256_*` tests — these do not touch pricing code paths.
- Cross-language: `pytest bindings/python/tests/` 370/370 pass including the new pricing test.

### Design decisions locked
- **Proto shape: string blob** (`pricing_json`) mirroring `defaults_json`, not a nested `message Pricing`. Discussed in the triage response; the string-blob pattern is consistent with existing precedent and can be migrated to a nested type later without a breaking change.

---

## What

Adds an optional `Pricing` field to `ModelInfo` so providers can surface
per-model pricing (input/output/cache rates per million tokens, currency,
and an optional `as_of` date) through `/v1/models`.

## Why

Today HTTP-bridge applications (e.g. `amplifier-app-opencode`) hand-maintain
their own pricing tables because pricing isn't part of model info on the
wire. This forces drift whenever provider pricing changes and leaves
end-users seeing stale cost estimates. Filed as
microsoft-amplifier/amplifier-support#295.

The fix is to expose the pricing data the provider modules **already
maintain internally** (each has a `_RATES` dict used for per-turn cost
accounting) through the public `ModelInfo` contract. No new source of
truth — we're promoting an existing one.

## What's in this PR

- New `Pricing` pydantic model in `python/amplifier_core/models.py`
  - `input_per_million`, `output_per_million` (required floats)
  - `cache_read_per_million`, `cache_write_per_million` (optional)
  - `currency` (defaults to `"USD"`)
  - `as_of` (optional date for staleness tracking)
- Optional `pricing: Pricing | None = None` field on `ModelInfo` (default None — backwards compatible)
- `Pricing` exported via `python/amplifier_core/__init__.py`
- Smoke tests in `tests/test_model_info_pricing.py` covering round-trip serialization and the `pricing=None` case

## Compatibility

Backwards-compatible. Existing providers that don't populate `pricing`
continue to work; the field is `None` by default. Existing consumers that
don't read `pricing` are unaffected.

## Companion PR

Partner change in `amplifier-module-provider-anthropic` populates the new
field from the existing `_RATES` table: https://github.com/microsoft/amplifier-module-provider-anthropic/pull/63

## Validation

Validated end-to-end in a Digital Twin Universe environment with both
patches active:
- `amplifier-core` patch installed, `Pricing` importable, field present on `ModelInfo`
- `AnthropicProvider.list_models()` returns models with populated pricing
- `ModelInfo.model_dump(mode="json")` emits the expected wire shape
- Opus values (5.0 / 25.0 USD per million in/out) match the expected rate sheet

## Scope

This is the minimum viable slice — `amplifier-core` schema change here,
companion `amplifier-module-provider-anthropic` change in the partner PR.
Other providers (`openai`, `azure-openai`, `gemini`, `vllm`, `ollama`) are
follow-up work and will land in separate PRs.

